### PR TITLE
Remove "v" prefix from new revision when formatting change log

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/ChangeLogFormatter.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/ChangeLogFormatter.kt
@@ -26,7 +26,7 @@ fun formatChangeLog(contributors: Set<String>,
         "commitCount" to "$commitCount",
         "repoUrl" to githubRepoUrl,
         "previousRev" to gitRepoConfig.previousRevision,
-        "newRev" to "v${gitRepoConfig.revision}",
+        "newRev" to gitRepoConfig.revision,
         "contributors" to contributors.joinToString(", "),
         "improvements" to formatImprovements(tickets, changelogConfig.categoryConfig.categoryOrder)
     )


### PR DESCRIPTION
I think this is what causes the version to be vvX.Y.Z instead of just
vX.Y.Z