### PR TITLE
Upgrade to Kotlin 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit-jupiter.version>5.6.0</junit-jupiter.version>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
+        <kotlin.version>1.5.0</kotlin.version>
     </properties>
 
     <repositories>
@@ -31,7 +33,7 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>1.4.21</version>
+                <version>${kotlin.version}</version>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -74,43 +76,57 @@
         <dependency>
             <groupId>org.kiwiproject</groupId>
             <artifactId>kiwi</artifactId>
-            <version>0.18.0</version>
+            <version>0.22.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.xenomachina</groupId>
             <artifactId>kotlin-argparser</artifactId>
             <version>2.0.7</version>
+            <!-- TODO This is brittle; it depends on Kotlin 1.2.41 -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
-            <version>2.11.1</version>
+            <version>2.12.3</version>
+            <!-- TODO This is brittle; it depends on Kotlin 1.4.21 -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test-junit5</artifactId>
-            <version>1.4.21</version>
+            <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>5.6.0</version>
+            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.6.0</version>
+            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>1.4.21</version>
+            <version>${kotlin.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
* Bump kotlin form 1.4.21 to 1.5.0
* Bump kiwi from 0.18.0 to 0.22.0
* Bump jackson-module-kotlin from 2.11.1 to 2.12.3
* Extract properties for kotlin and JUnit versions
* Add exclusions of kotlin-stdlib for kotlin-argparser (depends on
  1.2.41) and jackson-module-kotlin (depends on 1.4.21). When present
  these cause a nasty error and the app does not even run; it just
  explodes. See https://youtrack.jetbrains.com/issue/KT-37435