### PR TITLE
Handle case when issue body is null

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/GithubTicketFetcher.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/GithubTicketFetcher.kt
@@ -2,7 +2,9 @@ package org.kiwiproject.changelog
 
 import org.kiwiproject.changelog.config.ChangelogConfig
 import org.kiwiproject.changelog.config.GithubConfig
-import java.util.*
+import java.util.Collections
+import java.util.PriorityQueue
+import java.util.Queue
 
 class GithubTicketFetcher(
     githubConfig: GithubConfig,


### PR DESCRIPTION
* Modify isIssueOrLonePr to handle situation when issue["body"] returns
  null. Really not sure why we've never seen this before, unless it's
  a change GitHub made recently

Fixes #6