### PR TITLE
Update Kotlin, JUnit, and Kotlin Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,10 +13,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit-jupiter.version>5.7.2</junit-jupiter.version>
+        <junit-jupiter.version>5.8.1</junit-jupiter.version>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
-        <kotlin.version>1.5.30</kotlin.version>
+        <kotlin.version>1.5.31</kotlin.version>
     </properties>
 
     <repositories>
@@ -95,16 +95,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
-            <version>2.12.5</version>
-            <!-- TODO This is brittle; it depends on Kotlin 1.4.21 -->
+            <version>2.13.0</version>
             <exclusions>
+                <!-- Convergence error with kotlin-reflect 1.5.30 -->
                 <exclusion>
                     <groupId>org.jetbrains.kotlin</groupId>
                     <artifactId>kotlin-reflect</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
* Bump kotlin from 1.5.30 to 1.5.31
* Bump junit from 5.7.2 to 5.8.1
* Bump jackson-module-kotlin from 2.12.5 to 2.13.0