### PR TITLE
Bump various dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
-        <kotlin.version>1.6.10</kotlin.version>
+        <kotlin.version>1.6.20</kotlin.version>
     </properties>
 
     <repositories>
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
-            <version>2.13.1</version>
+            <version>2.13.2</version>
             <exclusions>
                 <!-- Convergence error with kotlin-reflect 1.5.30 -->
                 <exclusion>
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.kiwiproject</groupId>
             <artifactId>kiwi</artifactId>
-            <version>1.2.0</version>
+            <version>1.3.1</version>
         </dependency>
 
         <dependency>
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.10</version>
+            <version>1.2.11</version>
         </dependency>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
* Bump jackson-module-kotlin from 2.13.1 to 2.13.2
* Bump kiwi from 1.2.0 to 1.3.1
* Bump kotlin from 1.6.10 to 1.6.20
* Bump logback-classic from 1.2.10 to 1.2.11