### PR TITLE
Fix capitalization of GitHub and GitLab in comments and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Kiwiproject Changelog Generator
 
-Generates changelogs between two versions on GitHub or Gitlab.  The default options assume Github.
+Generates changelogs between two versions on GitHub or GitLab.  The default options assume GitHub.
 
-Here is a sample argument list that generates a changelog for the kiwi project (inside the kiwiproject organization on Github) for version v0.22.0. It creates the changelog comparing from revision v0.21.0 to v0.22.0 using the given working directory. It also maps several labels to categories, e.g. `-m bug:Bugs` maps from the GitHub label `bugs` to the changelog category "Bugs". And finally, it uses the `-O` option (you can also use `--category-order`) to specify the order of the categories in the generated changelog.
+Here is a sample argument list that generates a changelog for the kiwi project (inside the kiwiproject organization on GitHub) for version v0.22.0. It creates the changelog comparing from revision v0.21.0 to v0.22.0 using the given working directory. It also maps several labels to categories, e.g. `-m bug:Bugs` maps from the GitHub label `bugs` to the changelog category "Bugs". And finally, it uses the `-O` option (you can also use `--category-order`) to specify the order of the categories in the generated changelog.
 
 ```
 --repository kiwiproject/kiwi
@@ -25,4 +25,4 @@ Here is a sample argument list that generates a changelog for the kiwi project (
 
 The changelog produced using the above resulted in [this](https://github.com/kiwiproject/kiwi/releases/tag/v0.22.0) output.
 
-Note that you need a GitHub or Gitlab personal access token that has appropriate access to be able to read issues in the repository.
+Note that you need a GitHub or GitLab personal access token that has appropriate access to be able to read issues in the repository.

--- a/src/main/kotlin/org/kiwiproject/changelog/CommandLineArgs.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/CommandLineArgs.kt
@@ -15,13 +15,13 @@ class CommandLineArgs(parser: ArgParser) {
         GITLAB
     }
 
-    // Github/Gitlab Options
+    // GitHub/GitLab Options
     val provider by parser.option(ArgType.Choice<Provider>(), shortName = "P", description = "Host Git repository provider").default(Provider.GITHUB)
 
-    val repoHostApi by parser.option(ArgType.String, shortName = "a", fullName = "repo-host-api-url", description = "Url for Github or Gitlab API")
-    val repository by parser.option(ArgType.String, shortName = "r", description = "Name of the Github or Gitlab repository").required()
-    val repoHostToken by parser.option(ArgType.String, shortName = "t", fullName = "repo-host-token", description = "Authentication token for Github or Gitlab").required()
-    val repoHostUrl by parser.option(ArgType.String, shortName = "u", fullName = "repo-host-url", description = "Url for Github or Gitlab")
+    val repoHostApi by parser.option(ArgType.String, shortName = "a", fullName = "repo-host-api-url", description = "Url for GitHub or GitLab API")
+    val repository by parser.option(ArgType.String, shortName = "r", description = "Name of the GitHub or GitLab repository").required()
+    val repoHostToken by parser.option(ArgType.String, shortName = "t", fullName = "repo-host-token", description = "Authentication token for GitHub or GitLab").required()
+    val repoHostUrl by parser.option(ArgType.String, shortName = "u", fullName = "repo-host-url", description = "Url for GitHub or GitLab")
 
     // Git Repo Options
     val previousRevision by parser.option(ArgType.String, shortName = "p", fullName = "previous-rev", description = "Starting revision commit to search for changes").default("master")

--- a/src/main/kotlin/org/kiwiproject/changelog/GenerateChangelog.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/GenerateChangelog.kt
@@ -32,7 +32,7 @@ class GenerateChangelog(
             GitlabTicketFetcher(repoHostConfig, changeLogConfig).fetchTickets(tickets)
         }
 
-        println("Generating changelog based on ${improvements.size} tickets from Github")
+        println("Generating changelog based on ${improvements.size} tickets from GitHub")
         val githubUrl = "${repoHostConfig.url}/${repoHostConfig.repository}"
         val changeLog = formatChangeLog(contributors, improvements, commits.size, repoConfig, changeLogConfig, githubUrl)
 

--- a/src/main/kotlin/org/kiwiproject/changelog/GitLogProvider.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/GitLogProvider.kt
@@ -12,7 +12,7 @@ class GitLogProvider(val workingDir: File) {
         try {
             runProcess("git", "fetch", "origin", fetch)
         } catch (e: Exception) {
-            //This is a non blocking problem because we still are able to run git log locally
+            //This is a non-blocking problem because we still are able to run git log locally
             println("'git fetch' did not work, continuing running 'git log' locally.")
 
             //To avoid confusion, no stack trace in debug log, just the message:

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GithubApi.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GithubApi.kt
@@ -36,10 +36,10 @@ class GithubApi(val githubToken: String) {
         val rateRemaining = connection.getHeaderField("X-RateLimit-Remaining")
         val rateLimit = connection.getHeaderField("X-RateLimit-Limit")
 
-        println("Github API rate info => Remaining : $rateRemaining, Limit : $rateLimit, Reset at: $rateLimitReset")
+        println("GitHub API rate info => Remaining : $rateRemaining, Limit : $rateLimit, Reset at: $rateLimitReset")
 
         val link = connection.getHeaderField("Link")
-        println("Next page 'Link' from Github: $link")
+        println("Next page 'Link' from GitHub: $link")
 
         val content = call(method, connection)
         return Response(content, link)

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GithubListFetcher.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GithubListFetcher.kt
@@ -21,7 +21,7 @@ class GithubListFetcher(private val repoHostConfig: RepoHostConfig) {
 
     fun nextPage(): List<Map<String, Any>> {
         if (!hasNextPage()) {
-            throw IllegalStateException("Github API has no more issues to fetch. Did you run 'hasNextPage()' method?")
+            throw IllegalStateException("GitHub API has no more issues to fetch. Did you run 'hasNextPage()' method?")
         }
 
         val api = GithubApi(repoHostConfig.token)
@@ -37,7 +37,7 @@ class GithubListFetcher(private val repoHostConfig: RepoHostConfig) {
             return "none"
         }
 
-        // See Github API doc : https://developer.github.com/guides/traversing-with-pagination/
+        // See GitHub API doc : https://developer.github.com/guides/traversing-with-pagination/
         // Link: <https://api.github.com/repositories/6207167/issues?access_token=a0a4c0f41c200f7c653323014d6a72a127764e17&state=closed&filter=all&page=2>; rel="next",
         //       <https://api.github.com/repositories/62207167/issues?access_token=a0a4c0f41c200f7c653323014d6a72a127764e17&state=closed&filter=all&page=4>; rel="last"
         val linkRel = linkHeader.split(",")

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GithubTicketFetcher.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GithubTicketFetcher.kt
@@ -19,7 +19,7 @@ class GithubTicketFetcher(
             return listOf()
         }
 
-        println("Querying Github API for ${ticketIds.size} tickets.")
+        println("Querying GitHub API for ${ticketIds.size} tickets.")
         val tickets = queuedTicketNumbers(ticketIds)
 
         val resolvedTickets : MutableList<Ticket> = mutableListOf()
@@ -29,7 +29,7 @@ class GithubTicketFetcher(
                 resolvedTickets.addAll(extractImprovements(dropTicketsAboveMaxInPage(tickets, page), page))
             }
         } catch (e: Exception) {
-            throw RuntimeException("Problems fetching ${ticketIds.size} tickets from Github", e)
+            throw RuntimeException("Problems fetching ${ticketIds.size} tickets from GitHub", e)
         }
 
         return resolvedTickets

--- a/src/main/kotlin/org/kiwiproject/changelog/gitlab/GitlabApi.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/gitlab/GitlabApi.kt
@@ -36,10 +36,10 @@ class GitlabApi(val gitlabToken: String) {
         val rateRemaining = connection.getHeaderField("RateLimit-Remaining")
         val rateLimit = connection.getHeaderField("RateLimit-Limit")
 
-        println("Gitlab API rate info => Remaining : $rateRemaining, Limit : $rateLimit, Reset at: $rateLimitReset")
+        println("GitLab API rate info => Remaining : $rateRemaining, Limit : $rateLimit, Reset at: $rateLimitReset")
 
         val link = connection.getHeaderField("Link")
-        println("Next page 'Link' from Gitlab: $link")
+        println("Next page 'Link' from GitLab: $link")
 
         val content = call(method, connection)
         return Response(content, link)

--- a/src/main/kotlin/org/kiwiproject/changelog/gitlab/GitlabListFetcher.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/gitlab/GitlabListFetcher.kt
@@ -19,7 +19,7 @@ class GitlabListFetcher(private val repoHostConfig: RepoHostConfig) {
 
     fun nextPage(): List<Map<String, Any>> {
         if (!hasNextPage()) {
-            throw IllegalStateException("Gitlab API has no more issues to fetch. Did you run 'hasNextPage()' method?")
+            throw IllegalStateException("GitLab API has no more issues to fetch. Did you run 'hasNextPage()' method?")
         }
 
         val api = GitlabApi(repoHostConfig.token)
@@ -35,7 +35,9 @@ class GitlabListFetcher(private val repoHostConfig: RepoHostConfig) {
             return "none"
         }
 
-        // See Github API doc : https://developer.github.com/guides/traversing-with-pagination/
+        // TODO @chrisrohr the comment below references the GitHub documentation, not GitLab. Does this need
+        //  to change for GitLab? Looks like this was due to copying from GithubListFetcher.
+        // See GitHub API doc : https://developer.github.com/guides/traversing-with-pagination/
         // Link: <https://api.github.com/repositories/6207167/issues?access_token=a0a4c0f41c200f7c653323014d6a72a127764e17&state=closed&filter=all&page=2>; rel="next",
         //       <https://api.github.com/repositories/62207167/issues?access_token=a0a4c0f41c200f7c653323014d6a72a127764e17&state=closed&filter=all&page=4>; rel="last"
         val linkRel = linkHeader.split(",")

--- a/src/main/kotlin/org/kiwiproject/changelog/gitlab/GitlabTicketFetcher.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/gitlab/GitlabTicketFetcher.kt
@@ -18,7 +18,7 @@ class GitlabTicketFetcher(
             return listOf()
         }
 
-        println("Querying Gitlab API for ${ticketIds.size} tickets.")
+        println("Querying GitLab API for ${ticketIds.size} tickets.")
         val tickets = queuedTicketNumbers(ticketIds)
 
         val resolvedTickets : MutableList<Ticket> = mutableListOf()
@@ -28,7 +28,7 @@ class GitlabTicketFetcher(
                 resolvedTickets.addAll(extractImprovements(dropTicketsAboveMaxInPage(tickets, page), page))
             }
         } catch (e: Exception) {
-            throw RuntimeException("Problems fetching ${ticketIds.size} tickets from Gitlab", e)
+            throw RuntimeException("Problems fetching ${ticketIds.size} tickets from GitLab", e)
         }
 
         return resolvedTickets


### PR DESCRIPTION
* Change all Github to GitHub and Gitlab to GitLab in code comments
  and in println statements
* Add a TODO in GitlabListFetcher since there is a comment that
  references the GitHub documentation, instead of GitLab. Not sure
  if the comment is event relevant for GitLab or not.