### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,11 +13,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <junit-jupiter.version>5.9.1</junit-jupiter.version>
+        <junit-jupiter.version>5.9.3</junit-jupiter.version>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.jvmTarget>11</kotlin.compiler.jvmTarget>
-        <kotlin.version>1.7.22</kotlin.version>
-        <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
+        <kotlin.version>1.8.21</kotlin.version>
+        <maven-enforcer-plugin.version>3.3.0</maven-enforcer-plugin.version>
     </properties>
 
     <repositories>
@@ -146,7 +146,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>2.0.6</version>
+                <version>2.0.7</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -158,13 +158,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.1</version>
         </dependency>
 
         <dependency>
             <groupId>org.kiwiproject</groupId>
             <artifactId>kiwi</artifactId>
-            <version>2.3.0</version>
+            <version>2.5.0</version>
         </dependency>
 
         <dependency>
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.5</version>
+            <version>1.4.7</version>
         </dependency>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
* Bump JUnit Jupiter from 5.9.1 to 5.9.3
* Bump Kotlin from 1.7.22 to 1.8.21
* Bump SLF4J from 2.0.6 to 2.0.7
* Bump Jackson from 2.14.1 to 2.15.1
* Bump kiwi from 2.3.0 to 2.5.0
* Bump logback-classic from 1.4.5 to 1.4.7