### PR TITLE
Code cleanup

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/ChangeLogFormatter.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/ChangeLogFormatter.kt
@@ -62,7 +62,7 @@ fun replaceTokens(template: String, data: Map<String, String>) : String {
     val buffer = StringBuffer()
 
     while (matcher.find()) {
-        val replacement: String? = data.get(matcher.group(1))
+        val replacement: String? = data[matcher.group(1)]
         if (replacement != null) {
             matcher.appendReplacement(buffer, "")
             buffer.append(replacement)

--- a/src/main/kotlin/org/kiwiproject/changelog/GitLogProvider.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/GitLogProvider.kt
@@ -3,7 +3,7 @@ package org.kiwiproject.changelog
 import org.kiwiproject.io.KiwiIO
 import java.io.File
 
-class GitLogProvider(val workingDir: File) {
+class GitLogProvider(private val workingDir: File) {
 
     fun getLog(from: String, to: String, format: String): String {
         val fetch = "+refs/tags/$from:refs/tags/$from"
@@ -30,7 +30,7 @@ class GitLogProvider(val workingDir: File) {
         try {
             val process = ProcessBuilder(commandLine.asList()).directory(workingDir).redirectErrorStream(true).start()
             output = KiwiIO.readInputStreamOf(process)
-            exitValue = process.waitFor();
+            exitValue = process.waitFor()
         } catch (e: Exception) {
             throw RuntimeException("Problems executing command:\n  ${commandLine.joinToString(separator = "\n")}", e)
         }

--- a/src/main/kotlin/org/kiwiproject/changelog/config/ChangelogConfig.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/config/ChangelogConfig.kt
@@ -8,7 +8,6 @@ enum class OutputType {
     CONSOLE, FILE, GITHUB;
 
     companion object {
-        @Suppress("unused")
         fun entriesAsString() = entries.toTypedArray().contentToString()
     }
 }

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GithubApi.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GithubApi.kt
@@ -10,7 +10,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import javax.net.ssl.HttpsURLConnection
 
-class GithubApi(val githubToken: String) {
+class GithubApi(private val githubToken: String) {
     fun get(url: String): Response {
         return doRequest(url, "GET")
     }

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GithubListFetcher.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GithubListFetcher.kt
@@ -20,9 +20,7 @@ class GithubListFetcher(private val repoHostConfig: RepoHostConfig) {
     }
 
     fun nextPage(): List<Map<String, Any>> {
-        if (!hasNextPage()) {
-            throw IllegalStateException("GitHub API has no more issues to fetch. Did you run 'hasNextPage()' method?")
-        }
+        check(hasNextPage()) { "GitHub API has no more issues to fetch. Did you run 'hasNextPage()' method?" }
 
         val api = GithubApi(repoHostConfig.token)
         val response = api.get(nextPageUrl)

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GithubTicketFetcher.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GithubTicketFetcher.kt
@@ -4,7 +4,9 @@ import org.kiwiproject.changelog.Ticket
 import org.kiwiproject.changelog.config.ChangelogConfig
 import org.kiwiproject.changelog.config.RepoHostConfig
 import org.kiwiproject.changelog.parseTickets
-import java.util.*
+import java.util.Collections
+import java.util.PriorityQueue
+import java.util.Queue
 
 class GithubTicketFetcher(
     repoHostConfig: RepoHostConfig,
@@ -48,7 +50,7 @@ class GithubTicketFetcher(
         }
 
         val highestId = page[0]["number"] as Int?
-        while (!tickets.isEmpty() && tickets.peek() > highestId!!) {
+        while (tickets.isNotEmpty() && tickets.peek() > highestId!!) {
             tickets.poll()
         }
 


### PR DESCRIPTION
* Remove redundant suppression in ChangelogConfig
* Make constructor property private in GitLogProvider and GithubApi
* Remove redundant semicolon in GitLogProvider
* Use check() instead of conditional in GithubListFetcher
* Use isNotEmpty instead of !isEmpty in GithubTicketFetcher
* Use map indexing operator instead of get() call in ChangeLogFormatter.kt

Relates to #129