### PR TITLE
More code cleanup

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/ChangeLogFormatter.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/ChangeLogFormatter.kt
@@ -30,14 +30,14 @@ fun formatChangeLog(contributors: Set<String>,
     return replaceTokens(template, logData)
 }
 
-fun formatImprovements(tickets: List<Ticket>, categoryOrder: List<String>?) : String {
+fun formatImprovements(tickets: List<Ticket>, categoryOrder: List<String>) : String {
     if (tickets.isEmpty()) {
         return " - No notable improvements. No pull requests (issues) were referenced from commits."
     }
 
     val groupedTickets = tickets.groupBy { it.category }.toSortedMap()
 
-    val categories = if (categoryOrder.isNullOrEmpty()) groupedTickets.keys else categoryOrder
+    val categories = categoryOrder.ifEmpty { groupedTickets.keys }
 
     var improvementText = ""
 

--- a/src/main/kotlin/org/kiwiproject/changelog/Ticket.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/Ticket.kt
@@ -1,3 +1,3 @@
 package org.kiwiproject.changelog
 
-data class Ticket(val id: Int?, val title: String?, val url: String?, val category: String)
+data class Ticket(val id: Int, val title: String, val url: String, val category: String)

--- a/src/main/kotlin/org/kiwiproject/changelog/config/CategoryConfig.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/config/CategoryConfig.kt
@@ -1,6 +1,6 @@
 package org.kiwiproject.changelog.config
 
 data class CategoryConfig(val defaultCategory: String,
-                          val labelToCategoryMapping: Map<String, String>?,
-                          val alwaysIncludePRsFrom: List<String>?,
-                          val categoryOrder: List<String>?)
+                          val labelToCategoryMapping: Map<String, String>,
+                          val alwaysIncludePRsFrom: List<String>,
+                          val categoryOrder: List<String>)

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GithubApi.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GithubApi.kt
@@ -3,7 +3,7 @@ package org.kiwiproject.changelog.github
 import org.kiwiproject.io.KiwiIO
 import java.io.IOException
 import java.net.HttpURLConnection.HTTP_BAD_REQUEST
-import java.net.URL
+import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.time.ZoneId
@@ -17,7 +17,7 @@ class GithubApi(private val githubToken: String) {
 
     private fun doRequest(urlString: String, method: String, body: String? = null) : Response {
         println("Request url: $urlString")
-        val url = URL(urlString)
+        val url = URI(urlString).toURL()
 
         val connection : HttpsURLConnection = url.openConnection() as HttpsURLConnection
         connection.requestMethod = method


### PR DESCRIPTION
* Make properties in CategoryConfig and Ticket non-nullable.
* Replace deprecated URL constructor usage in GithubApi,
* Make code more readable in GithubTicketFetcher by extracting local vars and rename calculateCategory to findCategory.
* Replace !! in GithubTicketFetcher with Elvis + error.
* Replace if/else in ChangeLogFormatter.kt with ifEmpty.

Related to #129