### PR TITLE
Print warning when mapping not found for label

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/github/GithubTicketFetcher.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GithubTicketFetcher.kt
@@ -94,7 +94,12 @@ class GithubTicketFetcher(
             return defaultCategory
         }
 
-        val matchingLabel = labels.intersect(labelMapping.keys).firstOrNull() ?: return defaultCategory
-        return labelMapping[matchingLabel] ?: error("matchingLabel should never be null here")
+        val foundLabel = labels.intersect(labelMapping.keys).firstOrNull()
+        if (foundLabel == null) {
+            println("WARN: Using default category ($defaultCategory) b/c no mapping found for label(s): $labels")
+            return defaultCategory
+        }
+
+        return labelMapping[foundLabel] ?: error("matchingLabel should never be null here")
     }
 }


### PR DESCRIPTION
* Update GithubTicketFetcher#findCategory to print a warning if there is no label-to-category mapping, informing the user that the default category will be used.

Closes #140