### PR TITLE
Use dynamic version provider

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/ChangelogGeneratorMain.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/ChangelogGeneratorMain.kt
@@ -9,13 +9,14 @@ import org.kiwiproject.changelog.config.RepoHostConfig
 import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.ITypeConverter
+import picocli.CommandLine.IVersionProvider
 import picocli.CommandLine.Option
 import java.io.File
 import kotlin.system.exitProcess
 
 @Command(
     name = "ChangelogGenerator",
-    version = ["0.7.0"],
+    versionProvider = ChangelogGeneratorMain.VersionProvider::class,
     mixinStandardHelpOptions = true,
     usageHelpAutoWidth = true,
     description = [
@@ -24,6 +25,14 @@ import kotlin.system.exitProcess
         ""]
 )
 class ChangelogGeneratorMain : Runnable {
+
+    class VersionProvider : IVersionProvider {
+        override fun getVersion(): Array<String> {
+            val implVersion = ChangelogGeneratorMain::class.java.`package`.implementationVersion
+            val version = implVersion ?: "[unknown]"
+            return arrayOf(version)
+        }
+    }
 
     companion object {
         @JvmStatic

--- a/src/test/kotlin/org/kiwiproject/changelog/ChangelogGeneratorMainTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/ChangelogGeneratorMainTest.kt
@@ -1,0 +1,17 @@
+package org.kiwiproject.changelog
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("ChangelogGeneratorMain")
+class ChangelogGeneratorMainTest {
+
+    @Test
+    fun shouldGetVersion() {
+        val versionArray = ChangelogGeneratorMain.VersionProvider().version
+        assertThat(versionArray)
+            .describedAs("This should be 'unknown' in unit test environment")
+            .contains("[unknown]")
+    }
+}


### PR DESCRIPTION
* Use a VersionProvider instead of hard coding the version in ChangelogGeneratorMain
* In unit tests, Package#getImplementationVersion will always return null, so the code returns "[unknown]" in that situation. It allows a "test" even though it's not exactly awesome.

Closes #152