### PR TITLE
Preparation and refactoring for creating releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
 
         <!-- Versions for test dependencies -->
         <kiwi-test.version>3.3.0</kiwi-test.version>
+        <mockwebserver.version>4.12.0</mockwebserver.version>
 
         <!-- Versions for plugins -->
         <dokka-maven-plugin.version>1.9.20</dokka-maven-plugin.version>
@@ -159,6 +160,14 @@
                 </exclusion>
             </exclusions>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${mockwebserver.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GitHubReleaseManager.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GitHubReleaseManager.kt
@@ -1,0 +1,64 @@
+package org.kiwiproject.changelog.github
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import org.kiwiproject.changelog.config.RepoHostConfig
+
+/**
+ * Provides a simple way to interact with GitHub releases.
+ */
+class GitHubReleaseManager(
+    private val repoHostConfig: RepoHostConfig,
+    private val api: GithubApi,
+    private val mapper: ObjectMapper
+) {
+
+    private val createReleaseUrl = "${repoHostConfig.apiUrl}/repos/${repoHostConfig.repository}/releases"
+
+    /**
+     * Create a new release in GitHub for the given [tagName]
+     * with [releaseContent] as the contents of the new release.
+     *
+     * The tag must exist, otherwise an [IllegalStateException] is thrown.
+     *
+     * An [IllegalStateException] is thrown if the HTTP response from GitHub
+     * is not 201 Created.
+     */
+    fun createRelease(tagName: String, releaseContent: String): GitHubRelease {
+        checkTagExists(tagName)
+
+        val bodyParameters = mapOf<String, Any>(
+            "tag_name" to tagName,
+            "name" to tagName,
+            "body" to releaseContent
+        )
+        val bodyJson = mapper.writeValueAsString(bodyParameters)
+        val response = api.post(createReleaseUrl, bodyJson)
+        check(response.statusCode == 201) {
+            "Create release was unsuccessful. Status: ${response.statusCode}. Text: ${response.content}"
+        }
+
+        val responseContent = mapper.readValue<Map<String, Any>>(response.content)
+        return GitHubRelease.from(responseContent)
+    }
+
+    private fun checkTagExists(tagName: String) {
+        val tagUrl = tagUrlFor(tagName)
+        val getTagResponse = api.get(tagUrl)
+        check(getTagResponse.statusCode == 200) {
+            "Get tag was unsuccessful. Status: ${getTagResponse.statusCode}. Text: ${getTagResponse.content}"
+        }
+    }
+
+    private fun tagUrlFor(tagName: String) =
+        "${repoHostConfig.apiUrl}/repos/${repoHostConfig.repository}/refs/tags/$tagName"
+
+    class GitHubRelease(val htmlUrl: String) {
+        companion object {
+            fun from(responseContent: Map<String, Any>): GitHubRelease {
+                val htmlUrl = responseContent["html_url"] as String
+                return GitHubRelease(htmlUrl)
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/kiwiproject/changelog/extension/MockWebServerExtensions.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/extension/MockWebServerExtensions.kt
@@ -1,0 +1,68 @@
+package org.kiwiproject.changelog.extension
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+
+/**
+ * Calls [MockWebServer.url], trims any trailing
+ * slashes, and returns the URL as a String.
+ */
+fun MockWebServer.urlWithoutTrailingSlashAsString(): String =
+    urlWithoutTrailingSlashAsString("/")
+
+/**
+ * Calls [MockWebServer.url] with the given path, trims any trailing
+ * slashes, and returns the URL as a String.
+ *
+ * @param path the request path
+ */
+fun MockWebServer.urlWithoutTrailingSlashAsString(path: String): String =
+    url(path).toString().trimEnd { it == '/' }
+
+/**
+ * Calls [MockWebServer.takeRequest] method with a 1-second timeout.
+ * This method expects there to be a request, and asserts that there
+ * is a non-null request.
+ */
+fun MockWebServer.takeRequestWith1SecTimeout(): RecordedRequest =
+    this.takeRequest(1, TimeUnit.SECONDS)!!
+
+/**
+ *  Calls [MockWebServer.takeRequest] method with a 5-millisecond timeout.
+ *
+ *  Use this when you don't expect there to be any more requests, and
+ *  verify it by ensuring the returned `RecordedRequest` is `null`.
+ */
+fun MockWebServer.takeRequestWith1MilliTimeout() : RecordedRequest? =
+    this.takeRequest(1, TimeUnit.MILLISECONDS)
+
+/**
+ * Fixed value for the GitHub `X-RateLimit-Limit` header.
+ */
+private const val rateLimitLimit = 5000
+
+/**
+ * A variable for the GitHub `X-RateLimit-Remaining` header.
+ * Its value is decremented each time [addGitHubRateLimitHeaders] is called.
+ */
+private var rateLimitRemaining = 4999
+
+/**
+ * Adds the GitHub
+ * [rate limit headers](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#checking-the-status-of-your-rate-limit).
+ *
+ * The rate limit reset time is calculated as "now" plus 42 minutes (naturally).
+ */
+fun MockResponse.addGitHubRateLimitHeaders(): MockResponse {
+    rateLimitRemaining--
+    val rateLimitResetAt = Instant.now().plus(42, ChronoUnit.MINUTES).epochSecond
+
+    addHeader("X-RateLimit-Limit", rateLimitLimit)
+    addHeader("X-RateLimit-Remaining", rateLimitRemaining)
+    addHeader("X-RateLimit-Reset", rateLimitResetAt)
+    return this
+}

--- a/src/test/kotlin/org/kiwiproject/changelog/github/GitHubReleaseManagerTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/github/GitHubReleaseManagerTest.kt
@@ -1,0 +1,154 @@
+package org.kiwiproject.changelog.github
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.apache.commons.lang3.RandomStringUtils
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.kiwiproject.changelog.config.RepoHostConfig
+import org.kiwiproject.changelog.extension.addGitHubRateLimitHeaders
+import org.kiwiproject.changelog.extension.takeRequestWith1MilliTimeout
+import org.kiwiproject.changelog.extension.takeRequestWith1SecTimeout
+import org.kiwiproject.changelog.extension.urlWithoutTrailingSlashAsString
+import org.kiwiproject.test.util.Fixtures
+
+@DisplayName("GitHubReleaseManager")
+class GitHubReleaseManagerTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var releaseManager: GitHubReleaseManager
+    private val mapper = jacksonObjectMapper()
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+
+        val token = RandomStringUtils.randomAlphanumeric(40)
+        val repoHostConfig = RepoHostConfig(
+            "https://github.com",
+            server.urlWithoutTrailingSlashAsString(),
+            token,
+            "sleberknight/kotlin-scratch-pad"
+        )
+
+        releaseManager = GitHubReleaseManager(repoHostConfig, GithubApi(token), jacksonObjectMapper())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun shouldCreateNewRelease() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(getTagResponseJson())
+                .addGitHubRateLimitHeaders()
+        )
+
+        val releaseResponseJson = Fixtures.fixture("github-create-release-response.json")
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(201)
+                .setBody(releaseResponseJson)
+                .addHeader("Content-Type", "application/json; charset=utf-8")
+                .addGitHubRateLimitHeaders()
+        )
+
+        val (requestJson, requestMap) = getCreateReleaseRequest()
+        val tagName = requestMap["tag_name"] as String
+        val releaseContent = requestMap["body"] as String
+
+        val release = releaseManager.createRelease(tagName, releaseContent)
+
+        assertThat(release.htmlUrl)
+            .isEqualTo("https://github.com/sleberknight/kotlin-scratch-pad/releases/tag/v0.9.0-alpha")
+
+        assertCreateReleaseRequests(requestJson)
+    }
+
+    @Test
+    fun shouldThrowIllegalState_IfTagDoesNotExist_WhenCreatingRelease() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(404)
+                .setBody("Not Found")
+                .addGitHubRateLimitHeaders()
+        )
+
+        assertThatIllegalStateException()
+            .isThrownBy { releaseManager.createRelease("v0.9.0-alpha", "The release contents") }
+            .withMessage("Get tag was unsuccessful. Status: 404. Text: Not Found")
+
+        val getTagRequest = server.takeRequestWith1SecTimeout()
+        assertAll(
+            { assertThat(getTagRequest.method).isEqualTo("GET") },
+            { assertThat(getTagRequest.path).isEqualTo("/repos/sleberknight/kotlin-scratch-pad/refs/tags/v0.9.0-alpha") },
+            {
+                assertThat(server.takeRequestWith1MilliTimeout())
+                    .describedAs("The 'create release' request should not have happened")
+                    .isNull()
+            }
+        )
+    }
+
+    @Test
+    fun shouldThrowIllegalState_IfCreateReleaseFails_WhenCreatingRelease() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(getTagResponseJson())
+                .addHeader("Content-Type", "application/json; charset=utf-8")
+                .addGitHubRateLimitHeaders()
+        )
+
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(422)
+                .setBody("Validation failed")
+                .addHeader("Content-Type", "application/json; charset=utf-8")
+                .addGitHubRateLimitHeaders()
+        )
+
+        val (requestJson, requestMap) = getCreateReleaseRequest()
+        val tagName = requestMap["tag_name"] as String
+        val releaseContent = requestMap["body"] as String
+
+        assertThatIllegalStateException()
+            .isThrownBy { releaseManager.createRelease(tagName, releaseContent) }
+            .withMessage("Create release was unsuccessful. Status: 422. Text: Validation failed")
+
+        assertCreateReleaseRequests(requestJson)
+    }
+
+    private fun getTagResponseJson(): String = Fixtures.fixture("github-get-tag-response.json")
+
+    private fun getCreateReleaseRequest(): Pair<String, Map<String, Any>> {
+        val requestJson = Fixtures.fixture("github-create-release-request.json")
+        val requestMap = mapper.readValue<Map<String, Any>>(requestJson)
+        return Pair(requestJson, requestMap)
+    }
+
+    private fun assertCreateReleaseRequests(requestJson: String) {
+        val getTagRequest = server.takeRequestWith1SecTimeout()
+        val createReleaseRequest = server.takeRequestWith1SecTimeout()
+
+        assertAll(
+            { assertThat(getTagRequest.method).isEqualTo("GET") },
+            { assertThat(getTagRequest.path).isEqualTo("/repos/sleberknight/kotlin-scratch-pad/refs/tags/v0.9.0-alpha") },
+            { assertThat(createReleaseRequest.method).isEqualTo("POST") },
+            { assertThat(createReleaseRequest.path).isEqualTo("/repos/sleberknight/kotlin-scratch-pad/releases") },
+            { assertThat(createReleaseRequest.body.readUtf8()).isEqualToIgnoringWhitespace(requestJson) }
+        )
+    }
+}

--- a/src/test/kotlin/org/kiwiproject/changelog/github/GithubApiTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/github/GithubApiTest.kt
@@ -101,10 +101,10 @@ class GithubApiTest {
             val releaseResponseJson = Fixtures.fixture("github-create-release-response.json")
             `when`(httpResponse.body()).thenReturn(releaseResponseJson)
 
-            val nowAsEpochSeconds = Instant.now().plus(42, ChronoUnit.MINUTES).epochSecond
+            val rateLimitResetAt = Instant.now().plus(42, ChronoUnit.MINUTES).epochSecond
 
             val headerMap = mapOf(
-                "X-RateLimit-Reset" to listOf(nowAsEpochSeconds.toString()),
+                "X-RateLimit-Reset" to listOf(rateLimitResetAt.toString()),
                 "X-RateLimit-Remaining" to listOf("59"),
                 "X-RateLimit-Limit" to listOf("60"),
             )
@@ -124,7 +124,7 @@ class GithubApiTest {
                 { assertThat(response.linkHeader).isNull() },
                 { assertThat(response.rateLimitLimit).isEqualTo(60) },
                 { assertThat(response.rateLimitRemaining).isEqualTo(59) },
-                { assertThat(response.rateLimitResetAt).isEqualTo(nowAsEpochSeconds) }
+                { assertThat(response.rateLimitResetAt).isEqualTo(rateLimitResetAt) }
             )
 
             val httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest::class.java)

--- a/src/test/resources/github-create-release-request.json
+++ b/src/test/resources/github-create-release-request.json
@@ -1,7 +1,5 @@
 {
   "tag_name": "v0.9.0-alpha",
-  "target_commitish": "main",
-  "name": "0.9.0-alpha",
-  "draft": false,
+  "name": "v0.9.0-alpha",
   "body": "Testing release creation manually in Postman"
 }

--- a/src/test/resources/github-get-tag-response.json
+++ b/src/test/resources/github-get-tag-response.json
@@ -1,0 +1,10 @@
+{
+  "ref": "refs/tags/v0.9.0-alpha",
+  "node_id": "REF_kwDOLab6U7ZyZWZzL3RhZ3MvdjAuOS4wLWFscGhh",
+  "url": "https://api.github.com/repos/sleberknight/kotlin-scratch-pad/git/refs/tags/v0.9.0-alpha",
+  "object": {
+    "sha": "395467dea8959602e64b5a1cfd13964a830a66e7",
+    "type": "commit",
+    "url": "https://api.github.com/repos/sleberknight/kotlin-scratch-pad/git/commits/395467dea8959602e64b5a1cfd13964a830a66e7"
+  }
+}


### PR DESCRIPTION
This commit adds the GitHubReleaseManager class with a method for creating new releases in GitHub.

For the test, it uses the MockWebServer from OkHttp.

Related to #33