### PR TITLE
Implement GitHub release creation

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/config/CategoryConfig.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/config/CategoryConfig.kt
@@ -6,4 +6,16 @@ data class CategoryConfig(
     val alwaysIncludePRsFrom: List<String>,
     val categoryOrder: List<String>,
     val categoryToEmoji: Map<String, String?>
-)
+) {
+    companion object {
+        fun empty(): CategoryConfig {
+            return CategoryConfig(
+                defaultCategory = "Assorted",
+                labelToCategoryMapping = mapOf(),
+                alwaysIncludePRsFrom = listOf(),
+                categoryOrder = listOf(),
+                categoryToEmoji = mapOf()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GitHubReleaseManager.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GitHubReleaseManager.kt
@@ -26,6 +26,7 @@ class GitHubReleaseManager(
      */
     fun createRelease(tagName: String, releaseContent: String): GitHubRelease {
         checkTagExists(tagName)
+        // TODO: ensure release does NOT exist already
 
         val bodyParameters = mapOf<String, Any>(
             "tag_name" to tagName,
@@ -51,7 +52,7 @@ class GitHubReleaseManager(
     }
 
     private fun tagUrlFor(tagName: String) =
-        "${repoHostConfig.apiUrl}/repos/${repoHostConfig.repository}/refs/tags/$tagName"
+        "${repoHostConfig.apiUrl}/repos/${repoHostConfig.repository}/git/ref/tags/$tagName"
 
     class GitHubRelease(val htmlUrl: String) {
         companion object {

--- a/src/test/kotlin/org/kiwiproject/changelog/GenerateChangelogTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/GenerateChangelogTest.kt
@@ -1,0 +1,169 @@
+package org.kiwiproject.changelog
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.junitpioneer.jupiter.StdIo
+import org.junitpioneer.jupiter.StdOut
+import org.kiwiproject.changelog.config.CategoryConfig
+import org.kiwiproject.changelog.config.ChangelogConfig
+import org.kiwiproject.changelog.config.OutputType
+import org.kiwiproject.changelog.config.RepoConfig
+import org.kiwiproject.changelog.config.RepoHostConfig
+import org.kiwiproject.changelog.github.GitHubReleaseManager
+import org.kiwiproject.changelog.github.GitHubReleaseManager.GitHubRelease
+import org.kiwiproject.test.junit.jupiter.ClearBoxTest
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoInteractions
+import org.mockito.Mockito.`when`
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+
+@DisplayName("GenerateChangelog")
+class GenerateChangelogTest {
+
+    @Test
+    fun shouldConstructGithubReleaseManager() {
+        val repoHostConfig = repoHostConfig()
+        val repoConfig = repoConfig()
+        val changelogConfig = changelogConfig(OutputType.CONSOLE)
+
+        val generateChangelog = GenerateChangelog(repoHostConfig, repoConfig, changelogConfig)
+
+        assertThat(generateChangelog.releaseManager).isNotNull
+    }
+
+    @Nested
+    inner class WriteChangeLog {
+
+        @Test
+        @StdIo
+        fun shouldWriteToStdOut(stdout: StdOut) {
+            val repoHostConfig = repoHostConfig()
+            val repoConfig = repoConfig()
+            val changelogConfig = changelogConfig(OutputType.CONSOLE)
+            val releaseManager = mock(GitHubReleaseManager::class.java)
+
+            val generateChangelog = GenerateChangelog(repoHostConfig, repoConfig, changelogConfig, releaseManager)
+            val changeLog = changeLogText()
+            generateChangelog.writeChangeLog(changeLog)
+
+            val output = stdout.capturedLines().toList()
+            val expectedStdout = changeLog.split(System.lineSeparator())
+            assertThat(output).containsExactlyElementsOf(expectedStdout)
+
+            verifyNoInteractions(releaseManager)
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["", "parent-dir"])
+        fun shouldWriteToFile(parentDir: String, @TempDir directory: Path) {
+            val repoHostConfig = repoHostConfig()
+            val repoConfig = repoConfig()
+            val outputFile = Path.of(directory.toString(), parentDir, "changelog.txt")
+            val changelogConfig = changelogConfig(OutputType.FILE, outputFile)
+            val releaseManager = mock(GitHubReleaseManager::class.java)
+
+            val generateChangelog = GenerateChangelog(repoHostConfig, repoConfig, changelogConfig, releaseManager)
+            val changeLog = changeLogText()
+            generateChangelog.writeChangeLog(changeLog)
+
+            val readString = Files.readString(outputFile)
+            assertThat(readString).isEqualTo(changeLog)
+
+            verifyNoInteractions(releaseManager)
+        }
+
+        @ClearBoxTest
+        fun shouldWriteFile_WhenParentFile_IsNull() {
+            val repoHostConfig = repoHostConfig()
+            val repoConfig = repoConfig()
+            val outputFile = Path.of("changelog.txt")
+            val changelogConfig = changelogConfig(OutputType.FILE, outputFile)
+            val releaseManager = mock(GitHubReleaseManager::class.java)
+
+            val generateChangelog = GenerateChangelog(repoHostConfig, repoConfig, changelogConfig, releaseManager)
+
+            try {
+                generateChangelog.writeFile("The changes...", outputFile.toFile())
+            } finally {
+                Files.delete(outputFile)
+            }
+            verifyNoInteractions(releaseManager)
+        }
+
+        @Test
+        fun shouldThrowIllegalArgumentException_WhenNoOutputFile_IsProvided() {
+            val repoHostConfig = repoHostConfig()
+            val repoConfig = repoConfig()
+            val changelogConfig = changelogConfig(OutputType.FILE)
+            val releaseManager = mock(GitHubReleaseManager::class.java)
+
+            val generateChangelog = GenerateChangelog(repoHostConfig, repoConfig, changelogConfig, releaseManager)
+
+            assertThatIllegalStateException()
+                .isThrownBy { generateChangelog.writeChangeLog(changeLogText()) }
+                .withMessage("changeLogConfig.outputFile must not be null. The --output-file (or -f) option is required when output type is file.")
+
+            verifyNoInteractions(releaseManager)
+        }
+
+        @Test
+        fun shouldWriteToGitHub() {
+            val repoHostConfig = repoHostConfig()
+            val repoConfig = repoConfig()
+            val changelogConfig = changelogConfig(OutputType.GITHUB)
+            val releaseManager = mock(GitHubReleaseManager::class.java)
+            val htmlReleaseUrl =
+                "https://github.com/sleberknight/kotlin-scratch-pad/releases/tag/v0.9.0-alpha"
+            `when`(releaseManager.createRelease(anyString(), anyString()))
+                .thenReturn(GitHubRelease(htmlReleaseUrl))
+
+            val generateChangelog = GenerateChangelog(repoHostConfig, repoConfig, changelogConfig, releaseManager)
+            val changeLog = changeLogText()
+            generateChangelog.writeChangeLog(changeLog)
+
+            verify(releaseManager).createRelease(repoConfig.revision, changeLog)
+        }
+    }
+
+    private fun repoHostConfig() = RepoHostConfig(
+        url = "https://github.com",
+        apiUrl = "https://api.github.com",
+        token = "test_token_12345",
+        repository = "kiwiproject/kiwi-test"
+    )
+
+    private fun repoConfig() = RepoConfig(
+        workingDir = File("."),
+        previousRevision = "1.4.1",
+        revision = "v1.4.2"
+    )
+
+    private fun changelogConfig(outputType: OutputType, outputFile: Path? = null) = ChangelogConfig(
+        outputType = outputType,
+        outputFile = outputFile?.toFile(),
+        categoryConfig = CategoryConfig.empty()
+    )
+
+    private fun changeLogText() =
+        """
+        Improvements
+        * Add a new foo to the Bar 
+        
+        Bugs
+        * Fixed the thing
+        * Fixed the other thing
+        
+        Assorted
+        * Improved the README
+        """.trimIndent()
+}

--- a/src/test/kotlin/org/kiwiproject/changelog/config/CategoryConfigTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/config/CategoryConfigTest.kt
@@ -1,0 +1,23 @@
+package org.kiwiproject.changelog.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+
+@DisplayName("CategoryConfig")
+class CategoryConfigTest {
+
+    @Test
+    fun shouldCreateEmptyCategoryConfig() {
+        val emptyConfig = CategoryConfig.empty()
+
+        assertAll(
+            { assertThat(emptyConfig.defaultCategory).isEqualTo("Assorted") },
+            { assertThat(emptyConfig.labelToCategoryMapping).isEmpty() },
+            { assertThat(emptyConfig.alwaysIncludePRsFrom).isEmpty() },
+            { assertThat(emptyConfig.categoryOrder).isEmpty() },
+            { assertThat(emptyConfig.categoryToEmoji).isEmpty() }
+        )
+    }
+}

--- a/src/test/kotlin/org/kiwiproject/changelog/github/GitHubReleaseManagerTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/github/GitHubReleaseManagerTest.kt
@@ -93,7 +93,7 @@ class GitHubReleaseManagerTest {
         val getTagRequest = server.takeRequestWith1SecTimeout()
         assertAll(
             { assertThat(getTagRequest.method).isEqualTo("GET") },
-            { assertThat(getTagRequest.path).isEqualTo("/repos/sleberknight/kotlin-scratch-pad/refs/tags/v0.9.0-alpha") },
+            { assertThat(getTagRequest.path).isEqualTo("/repos/sleberknight/kotlin-scratch-pad/git/ref/tags/v0.9.0-alpha") },
             {
                 assertThat(server.takeRequestWith1MilliTimeout())
                     .describedAs("The 'create release' request should not have happened")
@@ -145,7 +145,7 @@ class GitHubReleaseManagerTest {
 
         assertAll(
             { assertThat(getTagRequest.method).isEqualTo("GET") },
-            { assertThat(getTagRequest.path).isEqualTo("/repos/sleberknight/kotlin-scratch-pad/refs/tags/v0.9.0-alpha") },
+            { assertThat(getTagRequest.path).isEqualTo("/repos/sleberknight/kotlin-scratch-pad/git/ref/tags/v0.9.0-alpha") },
             { assertThat(createReleaseRequest.method).isEqualTo("POST") },
             { assertThat(createReleaseRequest.path).isEqualTo("/repos/sleberknight/kotlin-scratch-pad/releases") },
             { assertThat(createReleaseRequest.body.readUtf8()).isEqualToIgnoringWhitespace(requestJson) }


### PR DESCRIPTION
This commit implements GitHub releases in GenerateChangelog when the output type is GITHUB.

It also fixes a bug from the previous commit, in which the URL to get a tag was incorrect.

Misc:

* Extracted writeChangeLog and writeFile methods to allow for unit testing the releases.
* Add a companion object to CategoryConfig with an "empty" factory method. This was mainly to make the unit tests a little nicer.

Closes #33