### PR TITLE
Add an option to close the milestone

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/GenerateChangelog.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/GenerateChangelog.kt
@@ -1,13 +1,11 @@
 package org.kiwiproject.changelog
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.google.common.annotations.VisibleForTesting
 import org.kiwiproject.changelog.config.ChangelogConfig
 import org.kiwiproject.changelog.config.OutputType
 import org.kiwiproject.changelog.config.RepoConfig
 import org.kiwiproject.changelog.config.RepoHostConfig
 import org.kiwiproject.changelog.github.GitHubReleaseManager
-import org.kiwiproject.changelog.github.GithubApi
 import org.kiwiproject.changelog.github.GithubTicketFetcher
 import java.io.File
 
@@ -15,11 +13,7 @@ class GenerateChangelog(
     private val repoHostConfig: RepoHostConfig,
     private val repoConfig: RepoConfig,
     private val changeLogConfig: ChangelogConfig,
-    internal val releaseManager: GitHubReleaseManager = GitHubReleaseManager(
-        repoHostConfig,
-        GithubApi(repoHostConfig.token),
-        jacksonObjectMapper()
-    )
+    private val releaseManager: GitHubReleaseManager
 ) {
 
     fun generate() {

--- a/src/test/kotlin/org/kiwiproject/changelog/ChangelogGeneratorMainTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/ChangelogGeneratorMainTest.kt
@@ -1,8 +1,18 @@
 package org.kiwiproject.changelog
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.kiwiproject.changelog.github.GitHubMilestoneManager
+import org.kiwiproject.changelog.github.GitHubMilestoneManager.GitHubMilestone
+import org.mockito.Mockito.anyInt
+import org.mockito.Mockito.anyString
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoMoreInteractions
+import org.mockito.Mockito.`when`
 
 @DisplayName("ChangelogGeneratorMain")
 class ChangelogGeneratorMainTest {
@@ -13,5 +23,62 @@ class ChangelogGeneratorMainTest {
         assertThat(versionArray)
             .describedAs("This should be 'unknown' in unit test environment")
             .contains("[unknown]")
+    }
+
+    @Nested
+    inner class CloseMilestone {
+
+        private val url = "https://github.com/acme/space-modulator/milestone/1"
+
+        private lateinit var milestoneManager : GitHubMilestoneManager
+
+        @BeforeEach
+        fun setUp() {
+            milestoneManager = mock(GitHubMilestoneManager::class.java)
+        }
+
+        @Test
+        fun shouldClose_BasedOnRevision() {
+            val number = 1
+            val title = "1.4.2"
+            val milestone = GitHubMilestone(number, title, url)
+            `when`(milestoneManager.getOpenMilestoneByTitle(anyString())).thenReturn(milestone)
+            `when`(milestoneManager.closeMilestone(anyInt())).thenReturn(milestone)
+
+            val closedMilestone = ChangelogGeneratorMain.closeMilestone(
+                revision = "v$title",
+                maybeMilestoneTitle = null,
+                milestoneManager = milestoneManager
+            )
+
+            assertThat(closedMilestone).isSameAs(milestone)
+
+            verifyMilestonManagerCalls(title, number)
+        }
+
+        @Test
+        fun shouldClose_UsingExplicitMilestone() {
+            val number = 4
+            val title = "1.5.0"
+            val milestone = GitHubMilestone(number, title, url)
+            `when`(milestoneManager.getOpenMilestoneByTitle(anyString())).thenReturn(milestone)
+            `when`(milestoneManager.closeMilestone(anyInt())).thenReturn(milestone)
+
+            val closedMilestone = ChangelogGeneratorMain.closeMilestone(
+                revision = "rel-1.5.0",
+                maybeMilestoneTitle = "1.5.0",
+                milestoneManager = milestoneManager
+            )
+
+            assertThat(closedMilestone).isSameAs(milestone)
+
+            verifyMilestonManagerCalls(title, number)
+        }
+
+        private fun verifyMilestonManagerCalls(title: String, number: Int) {
+            verify(milestoneManager).getOpenMilestoneByTitle(title)
+            verify(milestoneManager).closeMilestone(number)
+            verifyNoMoreInteractions(milestoneManager)
+        }
     }
 }

--- a/src/test/kotlin/org/kiwiproject/changelog/GenerateChangelogTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/GenerateChangelogTest.kt
@@ -30,17 +30,6 @@ import java.nio.file.Path
 @DisplayName("GenerateChangelog")
 class GenerateChangelogTest {
 
-    @Test
-    fun shouldConstructGithubReleaseManager() {
-        val repoHostConfig = repoHostConfig()
-        val repoConfig = repoConfig()
-        val changelogConfig = changelogConfig(OutputType.CONSOLE)
-
-        val generateChangelog = GenerateChangelog(repoHostConfig, repoConfig, changelogConfig)
-
-        assertThat(generateChangelog.releaseManager).isNotNull
-    }
-
     @Nested
     inner class WriteChangeLog {
 


### PR DESCRIPTION
* Add -C / --close-milestone flag option
* Add -M / --milestone-to-close option
* Add logic in ChangelogGeneratorMain to close the milestone
* Refactor GenerateChangelog to require a GitHubReleaseManager
* Refactor ChangelogGeneratorMain to create a single instance of GithubApi and ObjectMapper, and pass those to the constructors of GitHubReleaseManager and GitHubMilestoneManager

Closes #50