### PR TITLE
Use BOMs for Jackson and Kotlin to prevent dependency convergence errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,7 @@
 
     <properties>
         <!-- Versions for required dependencies -->
-        <jackson.version>2.17.1</jackson.version>
-        <jackson-module-kotlin.version>2.17.1</jackson-module-kotlin.version>
+        <jackson.version>2.17.2</jackson.version>
         <kiwi.version>4.1.0</kiwi.version>
         <kotlin.version>2.0.0</kotlin.version>
         <kotlin-logging-jvm.version>7.0.0</kotlin-logging-jvm.version>
@@ -45,6 +44,7 @@
         <!-- Versions for plugins -->
         <dokka-maven-plugin.version>1.9.20</dokka-maven-plugin.version>
         <exec-maven-plugin.version>3.3.0</exec-maven-plugin.version>
+        <kotlin-maven-plugin.version>2.0.0</kotlin-maven-plugin.version>
         <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
         <maven-enforcer-plugin.version>3.5.0</maven-enforcer-plugin.version>
         <maven-failsafe-plugin.version>3.3.0</maven-failsafe-plugin.version>
@@ -64,21 +64,19 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib</artifactId>
-                <version>${kotlin.version}</version>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-common</artifactId>
+                <artifactId>kotlin-bom</artifactId>
                 <version>${kotlin.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-jdk8</artifactId>
-                <version>${kotlin.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>
@@ -96,13 +94,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
-            <version>${jackson-module-kotlin.version}</version>
         </dependency>
 
         <dependency>
@@ -147,7 +143,6 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test-junit5</artifactId>
-            <version>${kotlin.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -186,7 +181,7 @@
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${kotlin.version}</version>
+                <version>${kotlin-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -256,7 +251,7 @@
             When generating releases, use Dokka to generate the javadocs.
             Unlike the docs, this performs the plugin in the package phase
             to ensure it happens before GPG signing (which happens at verify).
-            
+
             ref: https://kotlinlang.org/docs/dokka-introduction.html
         -->
         <profile>


### PR DESCRIPTION
* Update the POM to use the Jackson and Kotlin BOMs to control versions
* Create a separate version property for kotlin-maven-plugin
* Update Jackson version from 2.17.1 to 2.17.2