### PR TITLE
Remove secondary constructor from RepoConfig

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/config/RepoConfig.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/config/RepoConfig.kt
@@ -10,23 +10,6 @@ data class RepoConfig(
     private val milestone: String?
 ) {
 
-    constructor(
-        url: String,
-        apiUrl: String,
-        token: String,
-        repository: String,
-        previousRevision: String,
-        revision: String
-    ) : this(
-        url,
-        apiUrl,
-        token,
-        repository,
-        previousRevision,
-        revision,
-        null
-    )
-
     // Accepts v<major>.<minor>.<patch> and optionally a "pre-release" version
     // such as "-beta" or any other characters after the patch version.
     private val revisionPattern = Regex("v\\d+\\.\\d+\\.\\d+.*")

--- a/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
@@ -260,6 +260,10 @@ class AppTest {
     @Nested
     inner class CloseMilestone {
 
+        private val url = "https://fake-github.com"
+        private val apiUrl = "https://api.fake-github.com"
+        private val token = "abc-123"
+        private val repository = "fakeorg/fakerepo"
         private val urlPrefix = "https://fake-github.com/acme/space-modulator/milestones/"
 
         private lateinit var milestoneManager : GitHubMilestoneManager
@@ -278,7 +282,7 @@ class AppTest {
             `when`(milestoneManager.getOpenMilestoneByTitle(anyString())).thenReturn(milestone)
             `when`(milestoneManager.closeMilestone(anyInt())).thenReturn(milestone)
 
-            val repoConfig = RepoConfig("", "", "", "", "v1.4.1", "v${title}")
+            val repoConfig = RepoConfig(url, apiUrl, token, repository, "v1.4.1", "v${title}", milestone = null)
             val closedMilestone = App.closeMilestone(
                 repoConfig = repoConfig,
                 maybeMilestoneTitle = null,
@@ -299,7 +303,7 @@ class AppTest {
             `when`(milestoneManager.getOpenMilestoneByTitle(anyString())).thenReturn(milestone)
             `when`(milestoneManager.closeMilestone(anyInt())).thenReturn(milestone)
 
-            val repoConfig = RepoConfig("", "", "", "", "v1.4.1", "v${title}")
+            val repoConfig = RepoConfig(url, apiUrl, token, repository, "v1.4.1", "v${title}", milestone = null)
             val closedMilestone = App.closeMilestone(
                 repoConfig = repoConfig,
                 maybeMilestoneTitle = "1.5.0",

--- a/src/test/kotlin/org/kiwiproject/changelog/ChangeLogFormatterKtTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/ChangeLogFormatterKtTest.kt
@@ -42,7 +42,7 @@ class ChangeLogFormatterKtTest {
                 changelogConfig,
                 repoConfig.repoUrl()
             )
-            
+
             assertThat(changelog.trim())
                 .isEqualTo(
                     """
@@ -126,10 +126,11 @@ class ChangeLogFormatterKtTest {
         val repoConfig = RepoConfig(
             "https://fake-github.com",
             "https://api.fake-github.com",
-            "12345",
+            "token-12345",
             "fakeorg/fakerepo",
             "v1.4.1",
-            "v1.4.2"
+            "v1.4.2",
+            milestone = null
         )
         return repoConfig
     }

--- a/src/test/kotlin/org/kiwiproject/changelog/ChangelogGeneratorTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/ChangelogGeneratorTest.kt
@@ -322,7 +322,8 @@ class ChangelogGeneratorTest {
         token = "test_token_12345",
         repository = "kiwiproject/kiwi-test",
         previousRevision = "1.4.1",
-        revision = "v1.4.2"
+        revision = "v1.4.2",
+        milestone = null
     )
 
     private fun changelogConfig(outputType: OutputType, outputFile: Path? = null) = ChangelogConfig(

--- a/src/test/kotlin/org/kiwiproject/changelog/config/RepoConfigTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/config/RepoConfigTest.kt
@@ -45,7 +45,7 @@ class RepoConfigTest {
             v2.0.0-beta, 2.0.0-beta
             v2.0.0-gamma, 2.0.0-gamma""")
         fun shouldRemoveLeading_v_FromRevision(revision: String, expectedRevision: String) {
-            val repoConfig = RepoConfig(url, apiUrl, token, repository, previousRevision, revision)
+            val repoConfig = RepoConfig(url, apiUrl, token, repository, previousRevision, revision, milestone = null)
 
             assertThat(repoConfig.milestone()).isEqualTo(expectedRevision)
         }
@@ -59,7 +59,7 @@ class RepoConfigTest {
             "v1.4.",
         ])
         fun shouldThrowIllegalArgument_WhenRevisionIsNotInExpectedFormat(revision: String) {
-            val repoConfig = RepoConfig(url, apiUrl, token, repository, previousRevision, revision)
+            val repoConfig = RepoConfig(url, apiUrl, token, repository, previousRevision, revision, milestone = null)
 
             assertThatIllegalArgumentException().isThrownBy { repoConfig.milestone() }
         }
@@ -67,7 +67,7 @@ class RepoConfigTest {
 
     @Test
     fun shouldCreateRepoUrl() {
-        val repoConfig = RepoConfig(url, apiUrl, token, repository, previousRevision, "1.4.2")
+        val repoConfig = RepoConfig(url, apiUrl, token, repository, previousRevision, "1.4.2", milestone = null)
 
         assertThat(repoConfig.repoUrl()).isEqualTo("$url/$repository")
     }

--- a/src/test/kotlin/org/kiwiproject/changelog/github/GitHubMilestoneManagerTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/github/GitHubMilestoneManagerTest.kt
@@ -41,7 +41,8 @@ class GitHubMilestoneManagerTest {
             token,
             "sleberknight/kotlin-scratch-pad",
             "v1.4.0",
-            "v1.5.0"
+            "v1.5.0",
+            milestone = null
         )
 
         milestoneManager = GitHubMilestoneManager(repoConfig, GitHubApi(token), mapper)

--- a/src/test/kotlin/org/kiwiproject/changelog/github/GitHubReleaseManagerTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/github/GitHubReleaseManagerTest.kt
@@ -42,7 +42,8 @@ class GitHubReleaseManagerTest {
             token,
             "sleberknight/kotlin-scratch-pad",
             "v1.1.0",
-            "v1.2.0"
+            "v1.2.0",
+            milestone = null
         )
 
         releaseManager = GitHubReleaseManager(repoConfig, GitHubApi(token), mapper)

--- a/src/test/kotlin/org/kiwiproject/changelog/github/GitHubSearchManagerTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/github/GitHubSearchManagerTest.kt
@@ -46,7 +46,8 @@ class GitHubSearchManagerTest {
             token,
             "kiwiproject/kiwiproject-changelog",
             "v0.11.0",
-            "v0.12.0"
+            "v0.12.0",
+            milestone = null
         )
 
         searchManager = GitHubSearchManager(repoConfig, GitHubApi(token), GitHubPagingHelper(), mapper)


### PR DESCRIPTION
* The RepoConfig secondary constructor is only used in tests, so remove it.
* Update tests to pass the milestone parameter
* Update AppTest to pass "realistic" values to RepoConfig constructor