### PR TITLE
Fix rate limit logging in GitHubApi

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/github/GitHubApi.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GitHubApi.kt
@@ -103,8 +103,8 @@ class GitHubApi(
                 val currentDateTime = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(now)
                 val rateLimitReset = epochSecondsAsIsoFormatted(rateLimitResetEpochSeconds)
                 val rateLimitLogMessage =
-                    "GitHub API rate info => Limit : $rateLimitLimit, Remaining : $rateLimitRemaining, Current time: $currentDateTime, Reset at: $rateLimitReset, $humanTimeUntilReset"
-                LOG.at(humanTimeUntilReset.logLevel) { humanTimeUntilReset.message }
+                    "GitHub API rate info => Limit : $rateLimitLimit, Remaining : $rateLimitRemaining, Current time: $currentDateTime, Reset at: $rateLimitReset, ${humanTimeUntilReset.message}"
+                LOG.at(humanTimeUntilReset.logLevel) { this.message = rateLimitLogMessage }
 
                 val link = responseHeaders.firstValueOrNull("Link")
                 LOG.debug { "GitHub 'Link' header: $link" }


### PR DESCRIPTION
I messed up the rate limit logging in earlier refactoring. This fixes multiple problems:

* The rateLimitLogMessage was not used
* It was only logging the "time until reset" message
* It was not actually logging anything! (because was not using "at" correctly)