### PR TITLE
Verify release on GitHub does not already exist

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/github/GitHubReleaseManager.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GitHubReleaseManager.kt
@@ -21,11 +21,14 @@ class GitHubReleaseManager(
      *
      * The tag must exist, otherwise an [IllegalStateException] is thrown.
      *
+     * The release must not exist. If it does, an [IllegalStateException] is thrown.
+     *
      * An [IllegalStateException] is thrown if the HTTP response from GitHub
      * is not 201 Created.
      */
     fun createRelease(tagName: String, releaseContent: String): GitHubRelease {
         checkTagExists(tagName)
+        checkReleaseDoesNotExist(tagName)
 
         val bodyParameters = mapOf<String, Any>(
             "tag_name" to tagName,
@@ -52,6 +55,41 @@ class GitHubReleaseManager(
 
     private fun tagUrlFor(tagName: String) =
         "${repoConfig.apiUrl}/repos/${repoConfig.repository}/git/ref/tags/$tagName"
+
+    private fun checkReleaseDoesNotExist(tagName: String) {
+        // Implementation Note:
+        // This gets the 100 most recent releases. We do not bother paginating,
+        // and assume that no one would realistically try to release something
+        // that old. So, if they do, we will rely on GitHub returning a 422 if
+        // the release exists.
+
+        val releasesUrl = listReleasesUrlFor()
+        val listReleasesResponse = api.get(releasesUrl)
+        check(listReleasesResponse.statusCode == 200) {
+            "List releases was unsuccessful. Status: ${listReleasesResponse.statusCode}. Text: ${listReleasesResponse.content}"
+        }
+
+        val releasesList = mapper.readValue<List<Map<String, Any>>>(listReleasesResponse.content)
+        val releases = releasesList.map { release ->
+            mapOf("name" to release["name"], "tag_name" to release["tag_name"])
+        }
+
+        checkReleaseDoesNotExist(releases, tagName, "name", "with name")
+        checkReleaseDoesNotExist(releases, tagName, "tag_name", "associated with tag")
+    }
+
+    private fun listReleasesUrlFor() =
+        "${repoConfig.apiUrl}/repos/${repoConfig.repository}/releases?per_page=100"
+
+    private fun checkReleaseDoesNotExist(
+        releases: List<Map<String, Any?>>,
+        tagName: String,
+        property: String,
+        failurePhrase: String
+    ) {
+        val releaseDoesNotExist = releases.none { release -> release[property] == tagName }
+        check(releaseDoesNotExist) { "A release $failurePhrase $tagName already exists" }
+    }
 
     data class GitHubRelease(val htmlUrl: String) {
         companion object {

--- a/src/test/resources/github-list-releases-response-for-matching-name.json
+++ b/src/test/resources/github-list-releases-response-for-matching-name.json
@@ -1,0 +1,41 @@
+[
+  {
+    "url": "https://api.github.com/repos/sleberknight/kotlin-scratch-pad/releases/166322235",
+    "assets_url": "https://api.github.com/repos/sleberknight/kotlin-scratch-pad/releases/166322235/assets",
+    "upload_url": "https://uploads.github.com/repos/sleberknight/kotlin-scratch-pad/releases/166322235/assets{?name,label}",
+    "html_url": "https://github.com/sleberknight/kotlin-scratch-pad/releases/tag/v0.9.0-alpha",
+    "id": 166322235,
+    "author": {
+      "login": "sleberknight",
+      "id": 174812,
+      "node_id": "MDQ6VXNlcjE3NDgxMg==",
+      "avatar_url": "https://avatars.githubusercontent.com/u/174812?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/sleberknight",
+      "html_url": "https://github.com/sleberknight",
+      "followers_url": "https://api.github.com/users/sleberknight/followers",
+      "following_url": "https://api.github.com/users/sleberknight/following{/other_user}",
+      "gists_url": "https://api.github.com/users/sleberknight/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/sleberknight/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/sleberknight/subscriptions",
+      "organizations_url": "https://api.github.com/users/sleberknight/orgs",
+      "repos_url": "https://api.github.com/users/sleberknight/repos",
+      "events_url": "https://api.github.com/users/sleberknight/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/sleberknight/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "node_id": "RE_kwDOLab6U84J6eA7",
+    "tag_name": "v0.9.0-alpha",
+    "target_commitish": "main",
+    "name": "v0.9.0-alpha",
+    "draft": false,
+    "prerelease": false,
+    "created_at": "2024-07-16T01:24:17Z",
+    "published_at": "2024-07-20T02:45:50Z",
+    "assets": [],
+    "tarball_url": "https://api.github.com/repos/sleberknight/kotlin-scratch-pad/tarball/v0.9.0-alpha",
+    "zipball_url": "https://api.github.com/repos/sleberknight/kotlin-scratch-pad/zipball/v0.9.0-alpha",
+    "body": "Testing release creation manually in Postman"
+  }
+]

--- a/src/test/resources/github-list-releases-response-for-matching-tag_name.json
+++ b/src/test/resources/github-list-releases-response-for-matching-tag_name.json
@@ -1,0 +1,41 @@
+[
+  {
+    "url": "https://api.github.com/repos/sleberknight/kotlin-scratch-pad/releases/166322235",
+    "assets_url": "https://api.github.com/repos/sleberknight/kotlin-scratch-pad/releases/166322235/assets",
+    "upload_url": "https://uploads.github.com/repos/sleberknight/kotlin-scratch-pad/releases/166322235/assets{?name,label}",
+    "html_url": "https://github.com/sleberknight/kotlin-scratch-pad/releases/tag/v0.9.0-alpha",
+    "id": 166322235,
+    "author": {
+      "login": "sleberknight",
+      "id": 174812,
+      "node_id": "MDQ6VXNlcjE3NDgxMg==",
+      "avatar_url": "https://avatars.githubusercontent.com/u/174812?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/sleberknight",
+      "html_url": "https://github.com/sleberknight",
+      "followers_url": "https://api.github.com/users/sleberknight/followers",
+      "following_url": "https://api.github.com/users/sleberknight/following{/other_user}",
+      "gists_url": "https://api.github.com/users/sleberknight/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/sleberknight/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/sleberknight/subscriptions",
+      "organizations_url": "https://api.github.com/users/sleberknight/orgs",
+      "repos_url": "https://api.github.com/users/sleberknight/repos",
+      "events_url": "https://api.github.com/users/sleberknight/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/sleberknight/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "node_id": "RE_kwDOLab6U84J6eA7",
+    "tag_name": "v0.9.0-alpha",
+    "target_commitish": "main",
+    "name": "0.9.0-alpha",
+    "draft": false,
+    "prerelease": false,
+    "created_at": "2024-07-16T01:24:17Z",
+    "published_at": "2024-07-20T02:45:50Z",
+    "assets": [],
+    "tarball_url": "https://api.github.com/repos/sleberknight/kotlin-scratch-pad/tarball/v0.9.0-alpha",
+    "zipball_url": "https://api.github.com/repos/sleberknight/kotlin-scratch-pad/zipball/v0.9.0-alpha",
+    "body": "Testing release creation manually in Postman"
+  }
+]


### PR DESCRIPTION
* Modify GitHubReleaseManager to verify that a release on GitHub does not already with the same name.
* Update/add tests
* Add two test resource files: they are almost the same except one of them has a different name (0.9.0-alpha versus v0.9.0-alpha). This allows for testing the two different scenarios when a release already exists.

Closes #172