### PR TITLE
Move GitHubResponse to top-level class

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/github/GitHubApi.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GitHubApi.kt
@@ -3,20 +3,15 @@ package org.kiwiproject.changelog.github
 import com.google.common.annotations.VisibleForTesting
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.oshai.kotlinlogging.Level
-import org.kiwiproject.changelog.extension.firstValueAsLongOrThrow
 import org.kiwiproject.changelog.extension.firstValueOrNull
-import org.kiwiproject.changelog.extension.firstValueOrThrow
 import org.kiwiproject.changelog.extension.nowUtcTruncatedToSeconds
-import org.kiwiproject.changelog.extension.utcZonedDateTimeFromEpochSeconds
 import org.kiwiproject.time.KiwiDurationFormatters
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpRequest.BodyPublishers
-import java.net.http.HttpResponse
 import java.net.http.HttpResponse.BodyHandlers
 import java.time.Duration
-import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 
 private val LOG = KotlinLogging.logger {}
@@ -105,67 +100,6 @@ class GitHubApi(
         LOG.debug { "GitHub 'Link' header: $link" }
 
         return GitHubResponse.from(httpResponse)
-    }
-
-    /**
-     * Represents a generic GitHub response.
-     */
-    data class GitHubResponse(
-        val statusCode: Int,
-        val requestUri: URI,
-        val content: String,
-        val linkHeader: String?,
-        val rateLimitLimit: Long,
-        val rateLimitRemaining: Long,
-        val rateLimitResetAt: Long,
-        val rateLimitResource: String
-    ) {
-
-        /**
-         * The UTC date/time when the rate limit resets.
-         */
-        fun resetAt(): ZonedDateTime = utcZonedDateTimeFromEpochSeconds(rateLimitResetAt)
-
-        /**
-         * The duration until the rate limit resets.
-         */
-        fun timeUntilRateLimitResetsFrom(from: ZonedDateTime): Duration = Duration.between(from, resetAt())
-
-        /**
-         * There are requests remaining before the rate limit resets.
-         */
-        fun belowRateLimit(): Boolean = !exceededRateLimit()
-
-        /**
-         * There are no more requests remaining before the rate limit resets.
-         */
-        fun exceededRateLimit(): Boolean = rateLimitRemaining == 0L
-
-        companion object {
-
-            /**
-             * Create a new GitHubResponse from the given HttpResponse.
-             */
-            fun from(httpResponse: HttpResponse<String>): GitHubResponse {
-                val responseHeaders = httpResponse.headers()
-                val rateLimitLimit = responseHeaders.firstValueAsLongOrThrow("X-RateLimit-Limit")
-                val rateLimitRemaining = responseHeaders.firstValueAsLongOrThrow("X-RateLimit-Remaining")
-                val rateLimitResetEpochSeconds = responseHeaders.firstValueAsLongOrThrow("X-RateLimit-Reset")
-                val rateLimitResource = responseHeaders.firstValueOrThrow("X-RateLimit-Resource")
-                val link = responseHeaders.firstValueOrNull("Link")
-
-                return GitHubResponse(
-                    httpResponse.statusCode(),
-                    httpResponse.uri(),
-                    httpResponse.body(),
-                    link,
-                    rateLimitLimit,
-                    rateLimitRemaining,
-                    rateLimitResetEpochSeconds,
-                    rateLimitResource
-                )
-            }
-        }
     }
 }
 

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GitHubPagingHelper.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GitHubPagingHelper.kt
@@ -2,7 +2,6 @@ package org.kiwiproject.changelog.github
 
 import com.google.common.annotations.VisibleForTesting
 import org.apache.commons.lang3.StringUtils.abbreviate
-import org.kiwiproject.changelog.github.GitHubApi.GitHubResponse
 
 private const val NO_NEXT_PAGE = "none"
 

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GitHubResponse.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GitHubResponse.kt
@@ -1,0 +1,71 @@
+package org.kiwiproject.changelog.github
+
+import org.kiwiproject.changelog.extension.firstValueAsLongOrThrow
+import org.kiwiproject.changelog.extension.firstValueOrNull
+import org.kiwiproject.changelog.extension.firstValueOrThrow
+import org.kiwiproject.changelog.extension.utcZonedDateTimeFromEpochSeconds
+import java.net.URI
+import java.net.http.HttpResponse
+import java.time.Duration
+import java.time.ZonedDateTime
+
+/**
+ * Represents a generic GitHub response.
+ */
+data class GitHubResponse(
+    val statusCode: Int,
+    val requestUri: URI,
+    val content: String,
+    val linkHeader: String?,
+    val rateLimitLimit: Long,
+    val rateLimitRemaining: Long,
+    val rateLimitResetAt: Long,
+    val rateLimitResource: String
+) {
+
+    /**
+     * The UTC date/time when the rate limit resets.
+     */
+    fun resetAt(): ZonedDateTime = utcZonedDateTimeFromEpochSeconds(rateLimitResetAt)
+
+    /**
+     * The duration until the rate limit resets.
+     */
+    fun timeUntilRateLimitResetsFrom(from: ZonedDateTime): Duration = Duration.between(from, resetAt())
+
+    /**
+     * There are requests remaining before the rate limit resets.
+     */
+    fun belowRateLimit(): Boolean = !exceededRateLimit()
+
+    /**
+     * There are no more requests remaining before the rate limit resets.
+     */
+    fun exceededRateLimit(): Boolean = rateLimitRemaining == 0L
+
+    companion object {
+
+        /**
+         * Create a new GitHubResponse from the given HttpResponse.
+         */
+        fun from(httpResponse: HttpResponse<String>): GitHubResponse {
+            val responseHeaders = httpResponse.headers()
+            val rateLimitLimit = responseHeaders.firstValueAsLongOrThrow("X-RateLimit-Limit")
+            val rateLimitRemaining = responseHeaders.firstValueAsLongOrThrow("X-RateLimit-Remaining")
+            val rateLimitResetEpochSeconds = responseHeaders.firstValueAsLongOrThrow("X-RateLimit-Reset")
+            val rateLimitResource = responseHeaders.firstValueOrThrow("X-RateLimit-Resource")
+            val link = responseHeaders.firstValueOrNull("Link")
+
+            return GitHubResponse(
+                httpResponse.statusCode(),
+                httpResponse.uri(),
+                httpResponse.body(),
+                link,
+                rateLimitLimit,
+                rateLimitRemaining,
+                rateLimitResetEpochSeconds,
+                rateLimitResource
+            )
+        }
+    }
+}

--- a/src/test/kotlin/org/kiwiproject/changelog/github/GitHubPagingHelperTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/github/GitHubPagingHelperTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvFileSource
 import org.junit.jupiter.params.provider.ValueSource
-import org.kiwiproject.changelog.github.GitHubApi.GitHubResponse
 import java.net.URI
 import java.time.Instant
 import java.time.temporal.ChronoUnit

--- a/src/test/kotlin/org/kiwiproject/changelog/github/GitHubResponseTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/github/GitHubResponseTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.kiwiproject.changelog.extension.nowUtc
 import org.kiwiproject.changelog.extension.truncatedToSeconds
 import org.kiwiproject.changelog.extension.utcZonedDateTimeFromEpochSeconds
-import org.kiwiproject.changelog.github.GitHubApi.GitHubResponse
 import java.net.URI
 import java.time.Duration
 import java.time.ZonedDateTime


### PR DESCRIPTION
* Simplifies GitHubApi by de-cluttering it
* No longer need to import inner class