### PR TITLE
Move more data classes to top-level

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/github/GitHubChange.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GitHubChange.kt
@@ -1,7 +1,5 @@
 package org.kiwiproject.changelog.github
 
-import org.kiwiproject.changelog.github.GitHubSearchManager.GitHubIssue
-
 data class GitHubChange(val number: Int, val title: String, val htmlUrl: String, val category: String) {
 
     companion object {

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GitHubReleaseManager.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GitHubReleaseManager.kt
@@ -90,13 +90,13 @@ class GitHubReleaseManager(
         val releaseDoesNotExist = releases.none { release -> release[property] == tagName }
         check(releaseDoesNotExist) { "A release $failurePhrase $tagName already exists" }
     }
+}
 
-    data class GitHubRelease(val htmlUrl: String) {
-        companion object {
-            fun from(responseContent: Map<String, Any>): GitHubRelease {
-                val htmlUrl = responseContent["html_url"] as String
-                return GitHubRelease(htmlUrl)
-            }
+data class GitHubRelease(val htmlUrl: String) {
+    companion object {
+        fun from(responseContent: Map<String, Any>): GitHubRelease {
+            val htmlUrl = responseContent["html_url"] as String
+            return GitHubRelease(htmlUrl)
         }
     }
 }

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GitHubSearchManager.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GitHubSearchManager.kt
@@ -150,23 +150,24 @@ class GitHubSearchManager(
     private fun createCompareCommitsUrl(base: String, head: String): String =
         "${repoConfig.apiUrl}/repos/${repoConfig.repository}/compare/${base}...${head}?per_page=100&page=1"
 
-    data class GitHubIssue(
-        val title: String,
-        val number: Int,
-        val htmlUrl: String,
-        val labels: List<String>,
-        val user: GitHubUser?,
-        val createdAt: ZonedDateTime
-    )
+}
 
-    data class GitHubUser(
-        val name: String,
-        val login: String?,
-        val htmlUrl: String?
-    ) {
+data class GitHubIssue(
+    val title: String,
+    val number: Int,
+    val htmlUrl: String,
+    val labels: List<String>,
+    val user: GitHubUser?,
+    val createdAt: ZonedDateTime
+)
 
-        fun asMarkdown(): String {
-            return if (htmlUrl != null) "[$name](${htmlUrl})" else name
-        }
+data class GitHubUser(
+    val name: String,
+    val login: String?,
+    val htmlUrl: String?
+) {
+
+    fun asMarkdown(): String {
+        return if (htmlUrl != null) "[$name](${htmlUrl})" else name
     }
 }

--- a/src/test/kotlin/org/kiwiproject/changelog/ChangeLogFormatterKtTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/ChangeLogFormatterKtTest.kt
@@ -10,7 +10,7 @@ import org.kiwiproject.changelog.config.ChangelogConfig
 import org.kiwiproject.changelog.config.RepoConfig
 import org.kiwiproject.changelog.github.GitHubChange
 import org.kiwiproject.changelog.github.GitHubSearchManager.CommitAuthorsResult
-import org.kiwiproject.changelog.github.GitHubSearchManager.GitHubUser
+import org.kiwiproject.changelog.github.GitHubUser
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 

--- a/src/test/kotlin/org/kiwiproject/changelog/ChangelogGeneratorTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/ChangelogGeneratorTest.kt
@@ -15,12 +15,12 @@ import org.kiwiproject.changelog.config.CategoryConfig
 import org.kiwiproject.changelog.config.ChangelogConfig
 import org.kiwiproject.changelog.config.OutputType
 import org.kiwiproject.changelog.config.RepoConfig
+import org.kiwiproject.changelog.github.GitHubIssue
+import org.kiwiproject.changelog.github.GitHubRelease
 import org.kiwiproject.changelog.github.GitHubReleaseManager
-import org.kiwiproject.changelog.github.GitHubReleaseManager.GitHubRelease
 import org.kiwiproject.changelog.github.GitHubSearchManager
 import org.kiwiproject.changelog.github.GitHubSearchManager.CommitAuthorsResult
-import org.kiwiproject.changelog.github.GitHubSearchManager.GitHubIssue
-import org.kiwiproject.changelog.github.GitHubSearchManager.GitHubUser
+import org.kiwiproject.changelog.github.GitHubUser
 import org.kiwiproject.test.junit.jupiter.ClearBoxTest
 import org.kiwiproject.test.util.Fixtures
 import org.mockito.Mockito.anyString

--- a/src/test/kotlin/org/kiwiproject/changelog/github/GitHubChangeTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/github/GitHubChangeTest.kt
@@ -4,7 +4,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
-import org.kiwiproject.changelog.github.GitHubSearchManager.GitHubIssue
 import java.time.ZonedDateTime
 
 @DisplayName("GitHubChange")

--- a/src/test/kotlin/org/kiwiproject/changelog/github/GitHubSearchManagerTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/github/GitHubSearchManagerTest.kt
@@ -21,7 +21,6 @@ import org.kiwiproject.changelog.extension.addJsonContentTypeHeader
 import org.kiwiproject.changelog.extension.assertNoMoreRequests
 import org.kiwiproject.changelog.extension.takeRequestWith1SecTimeout
 import org.kiwiproject.changelog.extension.urlWithoutTrailingSlashAsString
-import org.kiwiproject.changelog.github.GitHubSearchManager.GitHubUser
 import org.kiwiproject.test.junit.jupiter.ClearBoxTest
 import org.kiwiproject.test.util.Fixtures
 


### PR DESCRIPTION
* Move GitHubRelease to top-level within GitHubReleaseManager.kt
* Move GitHubIssue and GitHubUser to top-level within GitHubSearchManager.kt
* Simplifies other imports, and we can easily move them separate files if we ever want/need to