### PR TITLE
Move another data class to top-level

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/App.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/App.kt
@@ -8,8 +8,8 @@ import org.kiwiproject.changelog.config.ConfigHelpers.externalConfig
 import org.kiwiproject.changelog.config.OutputType
 import org.kiwiproject.changelog.config.RepoConfig
 import org.kiwiproject.changelog.github.GitHubApi
+import org.kiwiproject.changelog.github.GitHubMilestone
 import org.kiwiproject.changelog.github.GitHubMilestoneManager
-import org.kiwiproject.changelog.github.GitHubMilestoneManager.GitHubMilestone
 import org.kiwiproject.changelog.github.GitHubPagingHelper
 import org.kiwiproject.changelog.github.GitHubReleaseManager
 import org.kiwiproject.changelog.github.GitHubSearchManager

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GitHubMilestoneManager.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GitHubMilestoneManager.kt
@@ -83,15 +83,15 @@ class GitHubMilestoneManager(
 
     private fun createMilestoneUrl(): String =
         "${repoConfig.apiUrl}/repos/${repoConfig.repository}/milestones"
+}
 
-    data class GitHubMilestone(val number: Int, val title: String, val htmlUrl: String) {
-        companion object {
-            fun from(responseContent: Map<String, Any>): GitHubMilestone {
-                val number = responseContent["number"] as Int
-                val title = responseContent["title"] as String
-                val htmlUrl = responseContent["html_url"] as String
-                return GitHubMilestone(number, title, htmlUrl)
-            }
+data class GitHubMilestone(val number: Int, val title: String, val htmlUrl: String) {
+    companion object {
+        fun from(responseContent: Map<String, Any>): GitHubMilestone {
+            val number = responseContent["number"] as Int
+            val title = responseContent["title"] as String
+            val htmlUrl = responseContent["html_url"] as String
+            return GitHubMilestone(number, title, htmlUrl)
         }
     }
 }

--- a/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
@@ -12,8 +12,8 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.kiwiproject.changelog.config.OutputType
 import org.kiwiproject.changelog.config.RepoConfig
+import org.kiwiproject.changelog.github.GitHubMilestone
 import org.kiwiproject.changelog.github.GitHubMilestoneManager
-import org.kiwiproject.changelog.github.GitHubMilestoneManager.GitHubMilestone
 import org.mockito.Mockito.anyInt
 import org.mockito.Mockito.anyString
 import org.mockito.Mockito.mock

--- a/src/test/kotlin/org/kiwiproject/changelog/github/GitHubMilestoneManagerTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/github/GitHubMilestoneManagerTest.kt
@@ -256,7 +256,7 @@ class GitHubMilestoneManagerTest {
         }
     }
 
-    private fun assertMilestone(milestone: GitHubMilestoneManager.GitHubMilestone) {
+    private fun assertMilestone(milestone: GitHubMilestone) {
         assertAll(
             { assertThat(milestone.number).isEqualTo(1) },
             { assertThat(milestone.title).isEqualTo("0.9.0-alpha") },


### PR DESCRIPTION
* Move GitHubMilestone to top-level within GitHubMilestoneManager.kt
* Simplifies other imports, and we can easily move them separate files if we ever want/need to
