### PR TITLE
Use shorter date/time format in generated changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ commits related to them, so the author information can only be obtained from the
 that occurred during the milestone.
 
 Labels on the issues and pull requests are mapped to a category.
-For example, the label "enhancement" might map to the category "Improvements".
+For example, the label "enhancement" might map to the category "Improvements."
 And you can also specify an emoji for each category for a nicer-looking changelog.
 
 ### How to prevent duplicates in change logs

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
     <profiles>
 
         <!--
-            When generating releases, use Dokka to generate the javadocs.
+            When generating releases, use Dokka to generate the Javadocs.
             Unlike the docs, this performs the plugin in the package phase
             to ensure it happens before GPG signing (which happens at verify).
 

--- a/src/main/kotlin/org/kiwiproject/changelog/config/ChangelogConfig.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/config/ChangelogConfig.kt
@@ -1,5 +1,6 @@
 package org.kiwiproject.changelog.config
 
+import org.kiwiproject.changelog.extension.nowUtc
 import java.io.File
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
@@ -12,10 +13,10 @@ enum class OutputType {
     }
 }
 
-data class ChangelogConfig(val date: ZonedDateTime = ZonedDateTime.now(),
+data class ChangelogConfig(val date: ZonedDateTime = nowUtc(),
                            val outputType: OutputType = OutputType.CONSOLE,
                            val outputFile: File? = null,
                            val categoryConfig: CategoryConfig) {
 
-    val dateString: String = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(date)
+    val dateString: String = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX").format(date)
 }

--- a/src/main/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfig.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfig.kt
@@ -3,7 +3,7 @@ package org.kiwiproject.changelog.config.external
 import com.fasterxml.jackson.annotation.JsonSetter
 import com.fasterxml.jackson.annotation.Nulls.AS_EMPTY
 
-// The JsonSetter is needed, otherwise null is the actual value when deserializing if there are no values in the YAML
+// The JsonSetter is necessary, otherwise null is the actual value when deserializing if there are no values in the YAML
 
 data class ExternalChangelogConfig(
     @JsonSetter(nulls = AS_EMPTY) val categories: List<ExternalCategory> = listOf(),

--- a/src/test/kotlin/org/kiwiproject/changelog/ChangeLogFormatterKtTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/ChangeLogFormatterKtTest.kt
@@ -47,7 +47,7 @@ class ChangeLogFormatterKtTest {
                 .isEqualTo(
                     """
                     ## Summary
-                    - 2024-07-13T15:44:45.000034567 - [4 commit(s)](https://fake-github.com/fakeorg/fakerepo/compare/v1.4.1...v1.4.2) by [dependabot[bot]](https://fake-github.com/apps/dependabot)
+                    - 2024-07-13T15:44:45Z - [4 commit(s)](https://fake-github.com/fakeorg/fakerepo/compare/v1.4.1...v1.4.2) by [dependabot[bot]](https://fake-github.com/apps/dependabot)
 
                      - No notable improvements. No issues or pull requests referenced milestone 1.4.2.
                 """.trimIndent()
@@ -104,7 +104,7 @@ class ChangeLogFormatterKtTest {
             assertThat(changelog.trim()).isEqualTo(
                 """
                 ## Summary
-                - 2024-07-13T15:44:45.000034567 - [4 commit(s)](https://fake-github.com/fakeorg/fakerepo/compare/v1.4.1...v1.4.2) by [Scott Leberknight](https://fake-github.com/sleberknight), [dependabot[bot]](https://fake-github.com/apps/dependabot)
+                - 2024-07-13T15:44:45Z - [4 commit(s)](https://fake-github.com/fakeorg/fakerepo/compare/v1.4.1...v1.4.2) by [Scott Leberknight](https://fake-github.com/sleberknight), [dependabot[bot]](https://fake-github.com/apps/dependabot)
 
                 ## Improvements 🚀
                 * Make the foo better [(#142)](https://fake-github.com/fakeorg/fakerepo/issues/142)

--- a/src/test/kotlin/org/kiwiproject/changelog/ChangelogGeneratorTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/ChangelogGeneratorTest.kt
@@ -69,7 +69,7 @@ class ChangelogGeneratorTest {
                 { assertThat(result.uniqueAuthorCount).isEqualTo(commitAuthorsResult.authors.size) },
                 { assertThat(result.changelogText.trimEnd()).isEqualTo(expectedChangelogContent()) },
                 { assertThat(output).contains("## Summary") },
-                { assertThat(output).contains("- 2024-07-14T17:29:42.000000129 - [4 commit(s)](https://fake-github.com/kiwiproject/kiwi-test/compare/1.4.1...v1.4.2) by [Alice](https://fake-github.com/bob42), [Bob](https://fake-github.com/bob42), [dependabot[bot]](https://fake-github.com/apps/dependabot)") },
+                { assertThat(output).contains("- 2024-07-14T17:29:42Z - [4 commit(s)](https://fake-github.com/kiwiproject/kiwi-test/compare/1.4.1...v1.4.2) by [Alice](https://fake-github.com/bob42), [Bob](https://fake-github.com/bob42), [dependabot[bot]](https://fake-github.com/apps/dependabot)") },
                 { assertThat(output).contains("## Enhancements") },
                 { assertThat(output).contains("* Add method foobar in BazUtils [(#142)](https://fake-github.com/fakeorg/fakerepo/issues/142)") },
                 { assertThat(output).contains("* Add BarFilter to prevent queue saturation [(#101)](https://fake-github.com/fakeorg/fakerepo/issue/101)") },

--- a/src/test/kotlin/org/kiwiproject/changelog/github/GitHubChangeTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/github/GitHubChangeTest.kt
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
-import java.time.ZonedDateTime
+import org.kiwiproject.changelog.extension.nowUtc
 
 @DisplayName("GitHubChange")
 class GitHubChangeTest {
@@ -17,7 +17,7 @@ class GitHubChangeTest {
             "https://fake-github.com/fakeorg/fakerepo/issues/43",
             listOf("enhancement"),
             null,
-            ZonedDateTime.now()
+            nowUtc()
         )
 
         val change = GitHubChange.from(issue, "Improvements")

--- a/src/test/kotlin/org/kiwiproject/changelog/github/GitHubResponseTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/github/GitHubResponseTest.kt
@@ -11,7 +11,6 @@ import org.kiwiproject.changelog.extension.truncatedToSeconds
 import org.kiwiproject.changelog.extension.utcZonedDateTimeFromEpochSeconds
 import java.net.URI
 import java.time.Duration
-import java.time.ZonedDateTime
 import kotlin.random.Random
 
 @DisplayName("GitHubResponse")
@@ -20,7 +19,7 @@ class GitHubResponseTest {
     @RepeatedTest(10)
     fun shouldReturnTheZonedDateTimeWhenRateLimitResetsAtUTC() {
         val randomMinutesFromNow = Random.nextLong(1, 61)
-        val rateLimitResetAt = ZonedDateTime.now().plusMinutes(randomMinutesFromNow)
+        val rateLimitResetAt = nowUtc().plusMinutes(randomMinutesFromNow)
         val rateLimitResetAtEpochSeconds = rateLimitResetAt.toEpochSecond()
 
         val response = GitHubResponse(
@@ -43,7 +42,7 @@ class GitHubResponseTest {
     @RepeatedTest(10)
     fun shouldCalculateTimeUntilRateLimitResets() {
         val randomMinutesFromNow = Random.nextLong(1, 61)
-        val rateLimitResetAt = ZonedDateTime.now().plusMinutes(randomMinutesFromNow).toEpochSecond()
+        val rateLimitResetAt = nowUtc().plusMinutes(randomMinutesFromNow).toEpochSecond()
 
         val response = GitHubResponse(
             200,
@@ -77,7 +76,7 @@ class GitHubResponseTest {
             null,
             10,
             rateLimitRemaining,
-            ZonedDateTime.now().plusMinutes(1).toEpochSecond(),
+            nowUtc().plusMinutes(1).toEpochSecond(),
             "core"
         )
 

--- a/src/test/resources/ChangelogGeneratorTest/test-changelog.md
+++ b/src/test/resources/ChangelogGeneratorTest/test-changelog.md
@@ -1,5 +1,5 @@
 ## Summary
-- 2024-07-14T17:29:42.000000129 - [4 commit(s)](https://fake-github.com/kiwiproject/kiwi-test/compare/1.4.1...v1.4.2) by [Alice](https://fake-github.com/bob42), [Bob](https://fake-github.com/bob42), [dependabot[bot]](https://fake-github.com/apps/dependabot)
+- 2024-07-14T17:29:42Z - [4 commit(s)](https://fake-github.com/kiwiproject/kiwi-test/compare/1.4.1...v1.4.2) by [Alice](https://fake-github.com/bob42), [Bob](https://fake-github.com/bob42), [dependabot[bot]](https://fake-github.com/apps/dependabot)
 
 ## Enhancements
 * Add method foobar in BazUtils [(#142)](https://fake-github.com/fakeorg/fakerepo/issues/142)


### PR DESCRIPTION
* Use a shorter date/time format. Example: 2024-07-16T23:37:44Z
* Replace calls to ZonedDateTime.now() with nowUtc()
* Fix a few minor grammatical errors.

Closes #211