### PR TITLE
Make exceptions consistent in HttpHeadersExtensions

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/extension/HttpHeadersExtensions.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/extension/HttpHeadersExtensions.kt
@@ -1,14 +1,21 @@
 package org.kiwiproject.changelog.extension
 
 import java.net.http.HttpHeaders
+import java.util.OptionalLong
 
 fun HttpHeaders.firstValueOrNull(name: String): String? = firstValue(name).orElse(null)
 
 fun HttpHeaders.firstValueOrThrow(name: String): String =
     firstValue(name).orElseThrow { newIllegalStateException(name) }
 
-fun HttpHeaders.firstValueAsLongOrThrow(name: String): Long =
-    firstValueAsLong(name).orElseThrow { newIllegalStateException(name) }
+fun HttpHeaders.firstValueAsLongOrThrow(name: String): Long {
+    val optionalLong: OptionalLong? = try {
+        firstValueAsLong(name)
+    } catch (e: Exception) {
+        throw IllegalStateException("$name header exists, but its value does not parse as a Long", e)
+    }
+    return optionalLong!!.orElseThrow { newIllegalStateException(name) }
+}
 
 private fun newIllegalStateException(name: String): IllegalStateException =
     IllegalStateException("$name header was expected, but does not exist (case-insensitive)")

--- a/src/test/kotlin/org/kiwiproject/changelog/extension/HttpHeadersExtensionsTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/extension/HttpHeadersExtensionsTest.kt
@@ -72,5 +72,14 @@ class HttpHeadersExtensionsTest {
                 .isThrownBy { httpHeaders.firstValueAsLongOrThrow("Some-Custom-Header") }
                 .withMessage("Some-Custom-Header header was expected, but does not exist (case-insensitive)")
         }
+
+        @Test
+        fun shouldThrowIllegalState_WhenHeaderExists_ButValueIsNotConvertibleToLong() {
+            assertThatIllegalStateException()
+                .isThrownBy { httpHeaders.firstValueAsLongOrThrow("X-RateLimit-Resource") }
+                .withMessage("X-RateLimit-Resource header exists, but its value does not parse as a Long")
+                .havingCause()
+                .isExactlyInstanceOf(NumberFormatException::class.java)
+        }
     }
 }


### PR DESCRIPTION
* Change firstValueAsLongOrThrow to throw IllegalStateException instead of NumberFormatException if the header exists but does not parse as a Long value. The NumberFormatException is now the cause of the IllegalStateException.

Closes #244