### PR TITLE
Add support for changelog summary and summary file options

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/ChangeLogFormatter.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/ChangeLogFormatter.kt
@@ -19,10 +19,15 @@ fun formatChangeLog(
         ## Summary
         - @date@ - [@commitCount@ commit(s)](@repoUrl@/compare/@previousRev@...@newRev@) by @authors@
 
-        @changes@
+        @summary@@changes@
     """.trimIndent()
 
     val authors = commitAuthorsResult.authors.joinToString(", ") { author -> author.asMarkdown() }
+
+    val summaryText = when (val summary = changelogConfig.summary?.trim()) {
+        null, "" -> ""
+        else -> summary + "\n\n"
+    }
 
     val logData = mapOf(
         "date" to changelogConfig.dateString,
@@ -31,6 +36,7 @@ fun formatChangeLog(
         "previousRev" to repoConfig.previousRevision,
         "newRev" to repoConfig.revision,
         "authors" to authors,
+        "summary" to summaryText,
         "changes" to formatChanges(
             gitHubChanges,
             repoConfig.milestone(),

--- a/src/main/kotlin/org/kiwiproject/changelog/config/ChangelogConfig.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/config/ChangelogConfig.kt
@@ -13,10 +13,13 @@ enum class OutputType {
     }
 }
 
-data class ChangelogConfig(val date: ZonedDateTime = nowUtc(),
-                           val outputType: OutputType = OutputType.CONSOLE,
-                           val outputFile: File? = null,
-                           val categoryConfig: CategoryConfig) {
+data class ChangelogConfig(
+    val date: ZonedDateTime = nowUtc(),
+    val outputType: OutputType = OutputType.CONSOLE,
+    val outputFile: File? = null,
+    val categoryConfig: CategoryConfig,
+    val summary: String? = null
+) {
 
     val dateString: String = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX").format(date)
 }

--- a/src/main/kotlin/org/kiwiproject/changelog/extension/StringExtensions.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/extension/StringExtensions.kt
@@ -1,0 +1,7 @@
+package org.kiwiproject.changelog.extension
+
+fun String.preview(maxChars: Int = 25): String {
+    val preview = take(maxChars)
+    val ellipsis = if (length > maxChars) "..." else ""
+    return "\"$preview$ellipsis\" [$length chars]"
+}

--- a/src/test/kotlin/org/kiwiproject/changelog/ChangeLogFormatterKtTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/ChangeLogFormatterKtTest.kt
@@ -5,6 +5,8 @@ import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.NullAndEmptySource
 import org.kiwiproject.changelog.config.CategoryConfig
 import org.kiwiproject.changelog.config.ChangelogConfig
 import org.kiwiproject.changelog.config.RepoConfig
@@ -23,11 +25,7 @@ class ChangeLogFormatterKtTest {
         @Test
         fun shouldGenerateEmptyChangelog_WhenThereAreNoChanges() {
             val authors = setOf(
-                GitHubUser(
-                    "dependabot[bot]",
-                    "dependabot[bot]",
-                    "https://fake-github.com/apps/dependabot"
-                )
+                GitHubUser("dependabot[bot]", "dependabot[bot]", "https://fake-github.com/apps/dependabot")
             )
             val authorsResult = CommitAuthorsResult(authors, 4)
             val changes = listOf<GitHubChange>()
@@ -54,44 +52,15 @@ class ChangeLogFormatterKtTest {
                 )
         }
 
-        @Test
-        fun shouldGenerateMarkdownFormattedChanges() {
-            val authors = setOf(
-                GitHubUser("Scott Leberknight", "sleberknight", "https://fake-github.com/sleberknight"),
-                GitHubUser("dependabot[bot]", "dependabot[bot]", "https://fake-github.com/apps/dependabot")
-            )
+        @ParameterizedTest
+        @NullAndEmptySource
+        fun shouldGenerateMarkdownFormattedChanges(summary: String?) {
+            val authors = gitHubUsers()
             val authorsResult = CommitAuthorsResult(authors, 4)
-
-            val changes = listOf(
-                GitHubChange(
-                    142,
-                    "Make the foo better",
-                    "https://fake-github.com/fakeorg/fakerepo/issues/142",
-                    "Improvements"
-                ),
-                GitHubChange(
-                    150,
-                    "Add more documentation to the bar and baz",
-                    "https://fake-github.com/fakeorg/fakerepo/issues/150",
-                    "Documentation"
-                ),
-                GitHubChange(
-                    151,
-                    "Bump quux-core from 1.6.0 to 1.7.2",
-                    "https://fake-github.com/fakeorg/fakerepo/pull/151",
-                    "Dependency Updates"
-                ),
-                GitHubChange(
-                    154,
-                    "Fix the space modulator",
-                    "https://fake-github.com/fakeorg/fakerepo/issues/154",
-                    "Bugs"
-                )
-            )
-
+            val changes = gitHubChanges()
             val repoConfig = repoConfig()
             val categoryConfig = categoryConfig()
-            val changelogConfig = changelogConfig(categoryConfig)
+            val changelogConfig = changelogConfig(categoryConfig, summary)
 
             val changelog = formatChangeLog(
                 authorsResult,
@@ -120,37 +89,122 @@ class ChangeLogFormatterKtTest {
             """.trimIndent()
             )
         }
-    }
 
-    private fun repoConfig(): RepoConfig {
-        val repoConfig = RepoConfig(
-            "https://fake-github.com",
-            "https://api.fake-github.com",
-            "token-12345",
-            "fakeorg/fakerepo",
-            "v1.4.1",
-            "v1.4.2",
-            milestone = null
+        @Test
+        fun shouldGenerateMarkdownFormattedChanges_WithSummary() {
+            val authors = gitHubUsers()
+            val authorsResult = CommitAuthorsResult(authors, 4)
+            val changes = gitHubChanges()
+            val repoConfig = repoConfig()
+            val categoryConfig = categoryConfig()
+            val summary = """
+            This is a summary of the release.
+            
+            It is a _neat_ release with lots of fun _new_ features!
+            """.trimIndent()
+            val changelogConfig = changelogConfig(categoryConfig, summary)
+
+            val changelog = formatChangeLog(
+                authorsResult,
+                changes,
+                repoConfig,
+                changelogConfig,
+                repoConfig.repoUrl()
+            )
+
+            assertThat(changelog.trim()).isEqualTo(
+                """
+                ## Summary
+                - 2024-07-13T15:44:45Z - [4 commit(s)](https://fake-github.com/fakeorg/fakerepo/compare/v1.4.1...v1.4.2) by [Scott Leberknight](https://fake-github.com/sleberknight), [dependabot[bot]](https://fake-github.com/apps/dependabot)
+
+                This is a summary of the release.
+                
+                It is a _neat_ release with lots of fun _new_ features!
+
+                ## Improvements 🚀
+                * Make the foo better [(#142)](https://fake-github.com/fakeorg/fakerepo/issues/142)
+
+                ## Bugs 🪲
+                * Fix the space modulator [(#154)](https://fake-github.com/fakeorg/fakerepo/issues/154)
+
+                ## Documentation 🗒️
+                * Add more documentation to the bar and baz [(#150)](https://fake-github.com/fakeorg/fakerepo/issues/150)
+
+                ## Dependency Updates ⚙️
+                * Bump quux-core from 1.6.0 to 1.7.2 [(#151)](https://fake-github.com/fakeorg/fakerepo/pull/151)
+            """.trimIndent()
+            )
+        }
+
+        private fun gitHubUsers(): Set<GitHubUser> {
+            val authors = setOf(
+                GitHubUser("Scott Leberknight", "sleberknight", "https://fake-github.com/sleberknight"),
+                GitHubUser("dependabot[bot]", "dependabot[bot]", "https://fake-github.com/apps/dependabot")
+            )
+            return authors
+        }
+
+        private fun gitHubChanges(): List<GitHubChange> {
+            val changes = listOf(
+                GitHubChange(
+                    142,
+                    "Make the foo better",
+                    "https://fake-github.com/fakeorg/fakerepo/issues/142",
+                    "Improvements"
+                ),
+                GitHubChange(
+                    150,
+                    "Add more documentation to the bar and baz",
+                    "https://fake-github.com/fakeorg/fakerepo/issues/150",
+                    "Documentation"
+                ),
+                GitHubChange(
+                    151,
+                    "Bump quux-core from 1.6.0 to 1.7.2",
+                    "https://fake-github.com/fakeorg/fakerepo/pull/151",
+                    "Dependency Updates"
+                ),
+                GitHubChange(
+                    154,
+                    "Fix the space modulator",
+                    "https://fake-github.com/fakeorg/fakerepo/issues/154",
+                    "Bugs"
+                )
+            )
+            return changes
+        }
+
+        private fun repoConfig(): RepoConfig {
+            val repoConfig = RepoConfig(
+                "https://fake-github.com",
+                "https://api.fake-github.com",
+                "token-12345",
+                "fakeorg/fakerepo",
+                "v1.4.1",
+                "v1.4.2",
+                milestone = null
+            )
+            return repoConfig
+        }
+
+        private fun changelogConfig(categoryConfig: CategoryConfig, summary: String? = null) = ChangelogConfig(
+            date = ZonedDateTime.of(2024, 7, 13, 15, 44, 45, 34567, ZoneOffset.UTC),
+            categoryConfig = categoryConfig,
+            summary = summary
         )
-        return repoConfig
-    }
 
-    private fun changelogConfig(categoryConfig: CategoryConfig) = ChangelogConfig(
-        date = ZonedDateTime.of(2024, 7, 13, 15, 44, 45, 34567, ZoneOffset.UTC),
-        categoryConfig = categoryConfig
-    )
-
-    private fun categoryConfig() = CategoryConfig(
-        "Assorted",
-        mapOf(),
-        listOf("Improvements", "Bugs", "Documentation", "Assorted", "Dependency Updates"),
-        mapOf(
-            "Improvements" to "🚀",
-            "Documentation" to "🗒️",
-            "Bugs" to "🪲",
-            "Dependency Updates" to "⚙️"
+        private fun categoryConfig() = CategoryConfig(
+            "Assorted",
+            mapOf(),
+            listOf("Improvements", "Bugs", "Documentation", "Assorted", "Dependency Updates"),
+            mapOf(
+                "Improvements" to "🚀",
+                "Documentation" to "🗒️",
+                "Bugs" to "🪲",
+                "Dependency Updates" to "⚙️"
+            )
         )
-    )
+    }
 
     @Nested
     inner class EnsureAllCategories {

--- a/src/test/kotlin/org/kiwiproject/changelog/extension/StringExtensionsTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/extension/StringExtensionsTest.kt
@@ -1,0 +1,64 @@
+package org.kiwiproject.changelog.extension
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("StringExtensions")
+class StringExtensionsTest {
+
+    @Nested
+    inner class Preview {
+
+        @Test
+        fun shouldNotAddEllipsisWhenStringIsShorterThanMax() {
+            val input = "Short summary"
+
+            val result = input.preview(25)
+
+            assertThat(result)
+                .isEqualTo("\"Short summary\" [13 chars]")
+        }
+
+        @Test
+        fun shouldNotAddEllipsisWhenStringLengthEqualsMax() {
+            val input = "a".repeat(25)
+
+            val result = input.preview(25)
+
+            assertThat(result)
+                .isEqualTo("\"${"a".repeat(25)}\" [25 chars]")
+        }
+
+        @Test
+        fun shouldAddEllipsisWhenStringIsLongerThanMax() {
+            val input = "This is a fun new release with exciting features"
+
+            val result = input.preview(25)
+
+            assertThat(result)
+                .isEqualTo("\"This is a fun new release...\" [48 chars]")
+        }
+
+        @Test
+        fun shouldRespectCustomMaxChars() {
+            val input = "abcdefghijklmnopqrstuvwxyz"
+
+            val result = input.preview(10)
+
+            assertThat(result)
+                .isEqualTo("\"abcdefghij...\" [26 chars]")
+        }
+
+        @Test
+        fun shouldHandleEmptyString() {
+            val input = ""
+
+            val result = input.preview(25)
+
+            assertThat(result)
+                .isEqualTo("\"\" [0 chars]")
+        }
+    }
+}


### PR DESCRIPTION
* Add summary and summaryFile options to App.
* Add nullable summary String to ChangelogConfig, which App passes to ChangeLogFormatter.
* Update ChangelogConfig to insert the summary text, if provided from either summary or summaryFile, into the change log.

Closes #270