### PR TITLE
Add configurable stripping of a 'v' prefix when creating next milestone

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfig.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfig.kt
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.Nulls.AS_EMPTY
 
 data class ExternalChangelogConfig(
     @JsonSetter(nulls = AS_EMPTY) val categories: List<ExternalCategory> = listOf(),
+    val stripVPrefixFromNextMilestone: Boolean = true,
 ) {
 
     fun labelCategoryMap(): Map<String, String> {

--- a/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
@@ -363,6 +363,22 @@ class AppTest {
         }
 
         @Test
+        fun `should strip v-prefix from next milestone when enabled`() {
+            assertThat(App.resolveNextMilestone("v1.2.3", true)).isEqualTo("1.2.3")
+        }
+
+        @Test
+        fun `should NOT strip v-prefix from next milestone when disabled`() {
+            assertThat(App.resolveNextMilestone("v1.2.3", false)).isEqualTo("v1.2.3")
+        }
+
+        @Test
+        fun `should NOT strip anything if no v-prefix exists`() {
+            assertThat(App.resolveNextMilestone("1.2.3", true)).isEqualTo("1.2.3")
+            assertThat(App.resolveNextMilestone("1.2.3", false)).isEqualTo("1.2.3")
+        }
+
+        @Test
         fun shouldCreateNewMilestone() {
             val number = 3
             val title = "4.2.0"

--- a/src/test/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfigTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfigTest.kt
@@ -65,7 +65,8 @@ class ExternalChangelogConfigTest {
                         "Infrastructure" to "🏗️"
                     )
                 )
-            }
+            },
+            { assertThat(config.stripVPrefixFromNextMilestone).isTrue() }
         )
     }
 
@@ -103,6 +104,14 @@ class ExternalChangelogConfigTest {
     }
 
     @Test
+    fun shouldReadConfig_ThatHasStripVPrefixFromNextMilestone() {
+        val yaml = Fixtures.fixture("kiwi-changelog-configs/kiwi-changelog-no-strip-v-prefix.yml")
+        val config = readConfig(yaml)
+
+        assertThat(config.stripVPrefixFromNextMilestone).isFalse()
+    }
+
+    @Test
     fun shouldReadEmptyConfig() {
         val yaml = Fixtures.fixture("kiwi-changelog-configs/empty-changelog.yml")
         val config = readConfig(yaml)
@@ -111,7 +120,8 @@ class ExternalChangelogConfigTest {
             { assertThat(config.categories).isEmpty() },
             { assertThat(config.labelCategoryMap()).isEmpty() },
             { assertThat(config.categoryOrder()).isEmpty() },
-            { assertThat(config.defaultCategory()).isNull() }
+            { assertThat(config.defaultCategory()).isNull() },
+            { assertThat(config.stripVPrefixFromNextMilestone).isTrue() }
         )
     }
 

--- a/src/test/resources/kiwi-changelog-configs/kiwi-changelog-no-strip-v-prefix.yml
+++ b/src/test/resources/kiwi-changelog-configs/kiwi-changelog-no-strip-v-prefix.yml
@@ -1,0 +1,28 @@
+---
+
+stripVPrefixFromNextMilestone: false
+
+categories:
+
+  - name: Improvements
+    labels:
+      - "new feature"
+      - "enhancement"
+
+  - name: Bugs
+    labels:
+      - "bug"
+
+  - name: Infrastructure
+    labels:
+      - infrastructure
+      - github_actions
+
+  - name: Assorted
+    labels:
+      - "code cleanup"
+      - "refactoring"
+
+  - name: "Dependency Updates"
+    labels:
+      - dependencies


### PR DESCRIPTION
- Add stripVPrefixFromNextMilestone to external configuration with a default value of true.
- Add --strip-v-prefix-from-next-milestone CLI option with the config fallback mentioned above.
- Apply v-prefix stripping only when creating the next milestone.
- Add validation and resolution logic for next milestone title.

Closes #320