### PR TITLE
fix: strip leading and trailing slashes from repository name

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/App.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/App.kt
@@ -284,7 +284,7 @@ class App : Runnable {
             repoHostUrl,
             repoHostApi,
             githubToken,
-            repository,
+            normalizeRepository(repository),
             previousRevision,
             revision,
             milestone
@@ -398,6 +398,9 @@ class App : Runnable {
 
         @VisibleForTesting
         internal data class AppResult(val exitCode: Int, val app: App)
+
+        @VisibleForTesting
+        fun normalizeRepository(repository: String): String = repository.trim('/')
 
         @VisibleForTesting
         fun resolveNextMilestone(title: String, stripVPrefix: Boolean): String {

--- a/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
@@ -433,6 +433,35 @@ class AppTest {
     }
 
     @Nested
+    inner class NormalizeRepository {
+
+        @Test
+        fun shouldNotChangeRepositoryWithNoSlashes() {
+            assertThat(App.normalizeRepository("kiwiproject/kiwi")).isEqualTo("kiwiproject/kiwi")
+        }
+
+        @Test
+        fun shouldStripTrailingSlash() {
+            assertThat(App.normalizeRepository("kiwiproject/kiwi/")).isEqualTo("kiwiproject/kiwi")
+        }
+
+        @Test
+        fun shouldStripLeadingSlash() {
+            assertThat(App.normalizeRepository("/kiwiproject/kiwi")).isEqualTo("kiwiproject/kiwi")
+        }
+
+        @Test
+        fun shouldStripBothLeadingAndTrailingSlashes() {
+            assertThat(App.normalizeRepository("/kiwiproject/kiwi/")).isEqualTo("kiwiproject/kiwi")
+        }
+
+        @Test
+        fun shouldStripMultipleLeadingAndTrailingSlashes() {
+            assertThat(App.normalizeRepository("//kiwiproject/kiwi//")).isEqualTo("kiwiproject/kiwi")
+        }
+    }
+
+    @Nested
     inner class ResolveSummary {
 
         private lateinit var spec: CommandLine.Model.CommandSpec


### PR DESCRIPTION
## Summary

- Normalizes the `--repository` argument by trimming leading/trailing slashes before constructing `RepoConfig`
- Handles the common case where bash autocomplete appends a trailing slash when the directory name matches the repo name
- Adds a `normalizeRepository` helper (consistent with the existing `resolveNextMilestone` pattern) with 5 unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)