### PR TITLE
feat: add option to auto-add v prefix to revisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ If the repository uses a different tag format, you need to specify the milestone
 For example, if tags use a format like `rel-1.4.2` then you can still generate the changelog
 as long as you specify the milestone.
 
+If you often forget to include the leading `v` when specifying revisions, you can use the
+`--add-v-prefix-to-revisions` option (or set `addVPrefixToRevisions: true` in the configuration
+file) to have it added automatically to both `--previous-rev` and `--revision` when not already
+present.
+
 Both the revision and the previous revision must be specified. The reason is so the
 changelog generator can find the unique _commit_ authors between these two revisions 
 and list them as contributors to the release. Note specifically that the contributors are
@@ -292,6 +297,22 @@ convention), you can disable this behavior in the external configuration file:
 ```yaml
 stripVPrefixFromNextMilestone: false
 ```
+
+### Adding the `v` prefix to revisions automatically
+
+When specifying `--previous-rev` and `--revision`, the values are expected to begin with `v`
+(e.g., `v1.4.2`). If you prefer to omit the `v` on the command line, you can enable automatic
+prefix addition in the external configuration file:
+
+```yaml
+addVPrefixToRevisions: true
+```
+
+When enabled, a leading `v` is added to both revisions if not already present. For example,
+passing `1.4.2` is treated as `v1.4.2`. This option is disabled by default.
+
+Setting this to `true` is equivalent to specifying `--add-v-prefix-to-revisions` on the
+command line.
 
 ### Using the Git annotated tag date as the release date
 

--- a/src/main/kotlin/org/kiwiproject/changelog/App.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/App.kt
@@ -223,6 +223,12 @@ class App : Runnable {
     )
     var stripVPrefixFromNextMilestone: Boolean? = null
 
+    @Option(
+        names = ["--add-v-prefix-to-revisions"],
+        description = ["Whether to add a leading 'v' to the previous and current revision if not already present (default: false)."]
+    )
+    var addVPrefixToRevisions: Boolean? = null
+
     // Summary options
 
     @Option(
@@ -280,13 +286,14 @@ class App : Runnable {
             defaultCategory,
             externalConfig
         )
+        val shouldAddVPrefix = addVPrefixToRevisions ?: externalConfig.addVPrefixToRevisions
         val repoConfig = RepoConfig(
             repoHostUrl,
             repoHostApi,
             githubToken,
             normalizeRepository(repository),
-            previousRevision,
-            revision,
+            normalizeRevision(previousRevision, shouldAddVPrefix),
+            normalizeRevision(revision, shouldAddVPrefix),
             milestone
         )
 
@@ -375,6 +382,7 @@ class App : Runnable {
         println("✔ createNextMilestone = $createNextMilestone")
         println("✔ closeMilestone = $closeMilestone")
         println("✔ stripVPrefixFromNextMilestone = $stripVPrefixFromNextMilestone")
+        println("✔ addVPrefixToRevisions = $addVPrefixToRevisions")
 
         // Debug options
         println("✔ debugArgs = $debugArgs")
@@ -401,6 +409,10 @@ class App : Runnable {
 
         @VisibleForTesting
         fun normalizeRepository(repository: String): String = repository.trim('/')
+
+        @VisibleForTesting
+        fun normalizeRevision(revision: String, addVPrefix: Boolean): String =
+            if (addVPrefix && !revision.startsWith("v")) "v$revision" else revision
 
         @VisibleForTesting
         fun resolveNextMilestone(title: String, stripVPrefix: Boolean): String {

--- a/src/main/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfig.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfig.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.Nulls.AS_EMPTY
 data class ExternalChangelogConfig(
     @JsonSetter(nulls = AS_EMPTY) val categories: List<ExternalCategory> = listOf(),
     val stripVPrefixFromNextMilestone: Boolean = true,
+    val addVPrefixToRevisions: Boolean = false,
     val useTagDateForRelease: Boolean = false
 ) {
 

--- a/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
@@ -70,6 +70,7 @@ class AppTest {
             { assertThat(app.closeMilestone).isFalse() },
             { assertThat(app.milestone).isNull() },
             { assertThat(app.createNextMilestone).isNull() },
+            { assertThat(app.addVPrefixToRevisions).isNull() },
         )
     }
 
@@ -189,6 +190,7 @@ class AppTest {
                 "--create-next-milestone",
                 "0.13.0",
                 "--strip-v-prefix-from-next-milestone",
+                "--add-v-prefix-to-revisions",
                 "--summary",
                 "This is a cool summary of the release!"
             )
@@ -246,6 +248,7 @@ class AppTest {
 
     private fun assertExecutionWithLongOnlyArgs(app: App) {
         assertThat(app.stripVPrefixFromNextMilestone).isTrue()
+        assertThat(app.addVPrefixToRevisions).isTrue()
     }
 
     @ParameterizedTest
@@ -429,6 +432,31 @@ class AppTest {
             assertThat(existingMilestone).isSameAs(milestone)
 
             verify(milestoneManager, only()).getOpenMilestoneByTitleOrNull(title)
+        }
+    }
+
+    @Nested
+    inner class NormalizeRevision {
+
+        @ParameterizedTest
+        @ValueSource(strings = ["v1.4.2", "v2.0.0-beta", "v1.0.0"])
+        fun shouldNotChangeRevision_WhenAlreadyHasVPrefix(revision: String) {
+            assertThat(App.normalizeRevision(revision, addVPrefix = true)).isEqualTo(revision)
+        }
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+            1.4.2, v1.4.2
+            2.0.0-beta, v2.0.0-beta
+            1.0.0, v1.0.0""")
+        fun shouldAddVPrefix_WhenEnabled(revision: String, expected: String) {
+            assertThat(App.normalizeRevision(revision, addVPrefix = true)).isEqualTo(expected)
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["1.4.2", "v1.4.2", "2.0.0-beta"])
+        fun shouldNotChangeRevision_WhenDisabled(revision: String) {
+            assertThat(App.normalizeRevision(revision, addVPrefix = false)).isEqualTo(revision)
         }
     }
 

--- a/src/test/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfigTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfigTest.kt
@@ -67,6 +67,7 @@ class ExternalChangelogConfigTest {
                 )
             },
             { assertThat(config.stripVPrefixFromNextMilestone).isTrue() },
+            { assertThat(config.addVPrefixToRevisions).isFalse() },
             { assertThat(config.useTagDateForRelease).isFalse() }
         )
     }
@@ -113,6 +114,14 @@ class ExternalChangelogConfigTest {
     }
 
     @Test
+    fun shouldReadConfig_ThatHasAddVPrefixToRevisions() {
+        val yaml = Fixtures.fixture("kiwi-changelog-configs/kiwi-changelog-add-v-prefix.yml")
+        val config = readConfig(yaml)
+
+        assertThat(config.addVPrefixToRevisions).isTrue()
+    }
+
+    @Test
     fun shouldReadConfig_ThatHasUseTagDateForRelease() {
         val yaml = Fixtures.fixture("kiwi-changelog-configs/kiwi-changelog-use-tag-date.yml")
         val config = readConfig(yaml)
@@ -131,6 +140,7 @@ class ExternalChangelogConfigTest {
             { assertThat(config.categoryOrder()).isEmpty() },
             { assertThat(config.defaultCategory()).isNull() },
             { assertThat(config.stripVPrefixFromNextMilestone).isTrue() },
+            { assertThat(config.addVPrefixToRevisions).isFalse() },
             { assertThat(config.useTagDateForRelease).isFalse() }
         )
     }

--- a/src/test/resources/kiwi-changelog-configs/kiwi-changelog-add-v-prefix.yml
+++ b/src/test/resources/kiwi-changelog-configs/kiwi-changelog-add-v-prefix.yml
@@ -1,0 +1,23 @@
+---
+
+addVPrefixToRevisions: true
+
+categories:
+
+  - name: Improvements
+    labels:
+      - "new feature"
+      - "enhancement"
+
+  - name: Bugs
+    labels:
+      - "bug"
+
+  - name: Assorted
+    labels:
+      - "code cleanup"
+      - "refactoring"
+
+  - name: "Dependency Updates"
+    labels:
+      - dependencies


### PR DESCRIPTION
## Summary

- Adds `--add-v-prefix-to-revisions` CLI option and `addVPrefixToRevisions` YAML config option (disabled by default)
- When enabled, automatically prepends `v` to both `--previous-rev` and `--revision` if not already present
- Mirrors the existing `stripVPrefixFromNextMilestone` pattern for both implementation and configuration
- Updates README with documentation in "How it works" and a new "External configuration" subsection

🤖 Generated with [Claude Code](https://claude.com/claude-code)