### PR TITLE
feat: make close-milestone negatable and add YAML config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,21 @@ passing `1.4.2` is treated as `v1.4.2`. This option is disabled by default.
 Setting this to `true` is equivalent to specifying `--add-v-prefix-to-revisions` on the
 command line.
 
+### Always closing the milestone
+
+By default, the milestone is only closed when `--close-milestone` (or `-C`) is passed on the
+command line. If you almost always want to close the milestone, you can enable this by default
+in the external configuration file:
+
+```yaml
+closeMilestone: true
+```
+
+When enabled, the milestone is closed automatically without needing to pass `--close-milestone`
+on every run. You can still suppress it for a specific run using `--no-close-milestone`.
+
+Setting this to `true` is equivalent to always specifying `--close-milestone` on the command line.
+
 ### Using the Git annotated tag date as the release date
 
 You can use the `useTagDateForRelease` option in the external configuration file

--- a/src/main/kotlin/org/kiwiproject/changelog/App.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/App.kt
@@ -195,9 +195,11 @@ class App : Runnable {
 
     @Option(
         names = ["-C", "--close-milestone"],
-        description = ["When set, the milestone associated with the revision is closed"]
+        negatable = true,
+        description = ["When set, the milestone associated with the revision is closed.",
+            "Use --no-close-milestone to override a closeMilestone: true setting in the configuration file."]
     )
-    var closeMilestone: Boolean = false
+    var closeMilestone: Boolean? = null
 
     @Option(
         names = ["-M", "--milestone"],
@@ -329,7 +331,8 @@ class App : Runnable {
 
         // Optional: close the milestone
         val milestoneManager = GitHubMilestoneManager(repoConfig, githubApi, mapper)
-        if (closeMilestone) {
+        val shouldCloseMilestone = closeMilestone ?: externalConfig.closeMilestone
+        if (shouldCloseMilestone) {
             val closedMilestone = closeMilestone(repoConfig, milestone, milestoneManager)
             println("✅ Closed milestone ${closedMilestone.title}. See it at ${closedMilestone.htmlUrl}")
         }

--- a/src/main/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfig.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfig.kt
@@ -9,6 +9,7 @@ data class ExternalChangelogConfig(
     @JsonSetter(nulls = AS_EMPTY) val categories: List<ExternalCategory> = listOf(),
     val stripVPrefixFromNextMilestone: Boolean = true,
     val addVPrefixToRevisions: Boolean = false,
+    val closeMilestone: Boolean = false,
     val useTagDateForRelease: Boolean = false
 ) {
 

--- a/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
@@ -67,7 +67,7 @@ class AppTest {
             { assertThat(app.categoryToEmojiMappings).isEmpty() },
             { assertThat(app.configFile).isNull() },
             { assertThat(app.ignoreConfigFiles).isFalse() },
-            { assertThat(app.closeMilestone).isFalse() },
+            { assertThat(app.closeMilestone).isNull() },
             { assertThat(app.milestone).isNull() },
             { assertThat(app.createNextMilestone).isNull() },
             { assertThat(app.addVPrefixToRevisions).isNull() },
@@ -433,6 +433,24 @@ class AppTest {
 
             verify(milestoneManager, only()).getOpenMilestoneByTitleOrNull(title)
         }
+    }
+
+    @Test
+    fun shouldSetCloseMilestoneToFalse_WhenNoCloseMilestoneIsSpecified() {
+        val (_, app) = App.execute(
+            arrayOf(
+                "--debug-args",  // prevent execution
+                "--repository",
+                "kiwiproject/kiwi",
+                "--previous-rev",
+                "v0.11.0",
+                "--revision",
+                "v0.12.0",
+                "--no-close-milestone"
+            )
+        )
+
+        assertThat(app.closeMilestone).isFalse()
     }
 
     @Nested

--- a/src/test/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfigTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfigTest.kt
@@ -68,6 +68,7 @@ class ExternalChangelogConfigTest {
             },
             { assertThat(config.stripVPrefixFromNextMilestone).isTrue() },
             { assertThat(config.addVPrefixToRevisions).isFalse() },
+            { assertThat(config.closeMilestone).isFalse() },
             { assertThat(config.useTagDateForRelease).isFalse() }
         )
     }
@@ -114,6 +115,14 @@ class ExternalChangelogConfigTest {
     }
 
     @Test
+    fun shouldReadConfig_ThatHasCloseMilestone() {
+        val yaml = Fixtures.fixture("kiwi-changelog-configs/kiwi-changelog-close-milestone.yml")
+        val config = readConfig(yaml)
+
+        assertThat(config.closeMilestone).isTrue()
+    }
+
+    @Test
     fun shouldReadConfig_ThatHasAddVPrefixToRevisions() {
         val yaml = Fixtures.fixture("kiwi-changelog-configs/kiwi-changelog-add-v-prefix.yml")
         val config = readConfig(yaml)
@@ -141,6 +150,7 @@ class ExternalChangelogConfigTest {
             { assertThat(config.defaultCategory()).isNull() },
             { assertThat(config.stripVPrefixFromNextMilestone).isTrue() },
             { assertThat(config.addVPrefixToRevisions).isFalse() },
+            { assertThat(config.closeMilestone).isFalse() },
             { assertThat(config.useTagDateForRelease).isFalse() }
         )
     }

--- a/src/test/resources/kiwi-changelog-configs/kiwi-changelog-close-milestone.yml
+++ b/src/test/resources/kiwi-changelog-configs/kiwi-changelog-close-milestone.yml
@@ -1,0 +1,23 @@
+---
+
+closeMilestone: true
+
+categories:
+
+  - name: Improvements
+    labels:
+      - "new feature"
+      - "enhancement"
+
+  - name: Bugs
+    labels:
+      - "bug"
+
+  - name: Assorted
+    labels:
+      - "code cleanup"
+      - "refactoring"
+
+  - name: "Dependency Updates"
+    labels:
+      - dependencies


### PR DESCRIPTION
## Summary

- Makes `--close-milestone` / `-C` negatable, auto-generating `--no-close-milestone` via picocli
- Changes `closeMilestone` field from `Boolean` to `Boolean?` so CLI presence/absence can be distinguished from explicit true/false
- Adds `closeMilestone: false` YAML config option so the milestone can be closed by default without passing the flag on every run
- CLI flag takes precedence over config file; `--no-close-milestone` overrides a `closeMilestone: true` setting
- Updates README with a new "Always closing the milestone" subsection under External configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)