### PR TITLE
feat: add opt-in OSC 8 hyperlinks for URLs in terminal status messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,22 @@ on every run. You can still suppress it for a specific run using `--no-close-mil
 
 Setting this to `true` is equivalent to always specifying `--close-milestone` on the command line.
 
+### Clickable URLs in terminal output
+
+When running in a terminal that supports [OSC 8 hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda)
+(such as iTerm2, GNOME Terminal, Windows Terminal, Kitty, and WezTerm), URLs in status
+messages can be rendered as clickable links. This is disabled by default since unsupported
+terminals may display the raw escape sequences.
+
+To enable, set the following in the external configuration file:
+
+```yaml
+hyperlinks: true
+```
+
+Setting this to `true` is equivalent to specifying `--hyperlinks` on the command line.
+You can override a `hyperlinks: true` setting for a specific run using `--no-hyperlinks`.
+
 ### Using the Git annotated tag date as the release date
 
 You can use the `useTagDateForRelease` option in the external configuration file

--- a/src/main/kotlin/org/kiwiproject/changelog/App.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/App.kt
@@ -231,6 +231,17 @@ class App : Runnable {
     )
     var addVPrefixToRevisions: Boolean? = null
 
+    // Output formatting options
+
+    @Option(
+        names = ["--hyperlinks"],
+        negatable = true,
+        description = ["Whether to render URLs as OSC 8 hyperlinks in terminal status messages.",
+            "Only takes effect in terminals that support OSC 8 hyperlinks (default: false).",
+            "Use --no-hyperlinks to override a hyperlinks: true setting in the configuration file."]
+    )
+    var hyperlinks: Boolean? = null
+
     // Summary options
 
     @Option(
@@ -332,9 +343,10 @@ class App : Runnable {
         // Optional: close the milestone
         val milestoneManager = GitHubMilestoneManager(repoConfig, githubApi, mapper)
         val shouldCloseMilestone = closeMilestone ?: externalConfig.closeMilestone
+        val shouldUseHyperlinks = hyperlinks ?: externalConfig.hyperlinks
         if (shouldCloseMilestone) {
             val closedMilestone = closeMilestone(repoConfig, milestone, milestoneManager)
-            println("✅ Closed milestone ${closedMilestone.title}. See it at ${closedMilestone.htmlUrl}")
+            println("✅ Closed milestone ${closedMilestone.title}. See it at ${formatUrl(closedMilestone.htmlUrl, shouldUseHyperlinks)}")
         }
 
         // Optional: create a new milestone
@@ -342,7 +354,7 @@ class App : Runnable {
             val shouldStripV = stripVPrefixFromNextMilestone ?: externalConfig.stripVPrefixFromNextMilestone
             val finalNextMilestone = resolveNextMilestone(createNextMilestone!!, shouldStripV)
             val newMilestone = createMilestone(finalNextMilestone, milestoneManager)
-            println("✅ Created new milestone ${newMilestone.title}. See it at ${newMilestone.htmlUrl}")
+            println("✅ Created new milestone ${newMilestone.title}. See it at ${formatUrl(newMilestone.htmlUrl, shouldUseHyperlinks)}")
         }
 
         println("🍻 Cheers!")
@@ -386,6 +398,7 @@ class App : Runnable {
         println("✔ closeMilestone = $closeMilestone")
         println("✔ stripVPrefixFromNextMilestone = $stripVPrefixFromNextMilestone")
         println("✔ addVPrefixToRevisions = $addVPrefixToRevisions")
+        println("✔ hyperlinks = $hyperlinks")
 
         // Debug options
         println("✔ debugArgs = $debugArgs")
@@ -409,6 +422,10 @@ class App : Runnable {
 
         @VisibleForTesting
         internal data class AppResult(val exitCode: Int, val app: App)
+
+        @VisibleForTesting
+        fun formatUrl(url: String, hyperlinks: Boolean): String =
+            if (hyperlinks) "\u001B]8;;$url\u001B\\$url\u001B]8;;\u001B\\" else url
 
         @VisibleForTesting
         fun normalizeRepository(repository: String): String = repository.trim('/')

--- a/src/main/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfig.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfig.kt
@@ -10,6 +10,7 @@ data class ExternalChangelogConfig(
     val stripVPrefixFromNextMilestone: Boolean = true,
     val addVPrefixToRevisions: Boolean = false,
     val closeMilestone: Boolean = false,
+    val hyperlinks: Boolean = false,
     val useTagDateForRelease: Boolean = false
 ) {
 

--- a/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
@@ -71,6 +71,7 @@ class AppTest {
             { assertThat(app.milestone).isNull() },
             { assertThat(app.createNextMilestone).isNull() },
             { assertThat(app.addVPrefixToRevisions).isNull() },
+            { assertThat(app.hyperlinks).isNull() },
         )
     }
 
@@ -191,6 +192,7 @@ class AppTest {
                 "0.13.0",
                 "--strip-v-prefix-from-next-milestone",
                 "--add-v-prefix-to-revisions",
+                "--hyperlinks",
                 "--summary",
                 "This is a cool summary of the release!"
             )
@@ -249,6 +251,7 @@ class AppTest {
     private fun assertExecutionWithLongOnlyArgs(app: App) {
         assertThat(app.stripVPrefixFromNextMilestone).isTrue()
         assertThat(app.addVPrefixToRevisions).isTrue()
+        assertThat(app.hyperlinks).isTrue()
     }
 
     @ParameterizedTest
@@ -451,6 +454,41 @@ class AppTest {
         )
 
         assertThat(app.closeMilestone).isFalse()
+    }
+
+    @Nested
+    inner class FormatUrl {
+
+        private val url = "https://github.com/kiwiproject/kiwi/milestones/42"
+
+        @Test
+        fun shouldReturnPlainUrl_WhenHyperlinksDisabled() {
+            assertThat(App.formatUrl(url, hyperlinks = false)).isEqualTo(url)
+        }
+
+        @Test
+        fun shouldReturnOsc8HyperlinkUrl_WhenHyperlinksEnabled() {
+            val result = App.formatUrl(url, hyperlinks = true)
+            assertThat(result).isEqualTo("\u001B]8;;$url\u001B\\$url\u001B]8;;\u001B\\")
+        }
+    }
+
+    @Test
+    fun shouldSetHyperlinksToFalse_WhenNoHyperlinksIsSpecified() {
+        val (_, app) = App.execute(
+            arrayOf(
+                "--debug-args",  // prevent execution
+                "--repository",
+                "kiwiproject/kiwi",
+                "--previous-rev",
+                "v0.11.0",
+                "--revision",
+                "v0.12.0",
+                "--no-hyperlinks"
+            )
+        )
+
+        assertThat(app.hyperlinks).isFalse()
     }
 
     @Nested

--- a/src/test/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfigTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfigTest.kt
@@ -69,6 +69,7 @@ class ExternalChangelogConfigTest {
             { assertThat(config.stripVPrefixFromNextMilestone).isTrue() },
             { assertThat(config.addVPrefixToRevisions).isFalse() },
             { assertThat(config.closeMilestone).isFalse() },
+            { assertThat(config.hyperlinks).isFalse() },
             { assertThat(config.useTagDateForRelease).isFalse() }
         )
     }
@@ -115,6 +116,14 @@ class ExternalChangelogConfigTest {
     }
 
     @Test
+    fun shouldReadConfig_ThatHasHyperlinks() {
+        val yaml = Fixtures.fixture("kiwi-changelog-configs/kiwi-changelog-hyperlinks.yml")
+        val config = readConfig(yaml)
+
+        assertThat(config.hyperlinks).isTrue()
+    }
+
+    @Test
     fun shouldReadConfig_ThatHasCloseMilestone() {
         val yaml = Fixtures.fixture("kiwi-changelog-configs/kiwi-changelog-close-milestone.yml")
         val config = readConfig(yaml)
@@ -151,6 +160,7 @@ class ExternalChangelogConfigTest {
             { assertThat(config.stripVPrefixFromNextMilestone).isTrue() },
             { assertThat(config.addVPrefixToRevisions).isFalse() },
             { assertThat(config.closeMilestone).isFalse() },
+            { assertThat(config.hyperlinks).isFalse() },
             { assertThat(config.useTagDateForRelease).isFalse() }
         )
     }

--- a/src/test/resources/kiwi-changelog-configs/kiwi-changelog-hyperlinks.yml
+++ b/src/test/resources/kiwi-changelog-configs/kiwi-changelog-hyperlinks.yml
@@ -1,0 +1,23 @@
+---
+
+hyperlinks: true
+
+categories:
+
+  - name: Improvements
+    labels:
+      - "new feature"
+      - "enhancement"
+
+  - name: Bugs
+    labels:
+      - "bug"
+
+  - name: Assorted
+    labels:
+      - "code cleanup"
+      - "refactoring"
+
+  - name: "Dependency Updates"
+    labels:
+      - dependencies


### PR DESCRIPTION
## Summary

- Adds `--hyperlinks` CLI option (negatable, generating `--no-hyperlinks`) and `hyperlinks: false` YAML config option
- When enabled, wraps URLs in status messages (milestone close/create) with OSC 8 escape sequences for clickable links in supported terminals (iTerm2, GNOME Terminal, Windows Terminal, Kitty, WezTerm, etc.)
- Disabled by default — unsupported terminals (e.g. macOS Terminal.app) would otherwise display raw escape sequences
- Only applies to status messages; changelog content is unaffected
- Updates README with a new "Clickable URLs in terminal output" subsection under External configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)