### PR TITLE
feat(config): report YAML deserialization problems to stdout

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/config/ConfigHelpers.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/config/ConfigHelpers.kt
@@ -1,8 +1,15 @@
 package org.kiwiproject.changelog.config
 
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.deser.DeserializationProblemHandler
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator
+import com.google.common.annotations.VisibleForTesting
+import org.kiwiproject.yaml.RuntimeYamlException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.kiwiproject.changelog.config.external.ExternalChangelogConfig
 import org.kiwiproject.json.LoggingDeserializationProblemHandler
@@ -71,14 +78,34 @@ internal object ConfigHelpers {
         return when (externalConfigYaml) {
             null -> ExternalChangelogConfig()
             else -> {
-                // TODO How to report deserialization problems? Just the WARN log? Add to ExternalChangelogConfig?
                 val yamlFactory = YAMLFactory().disable(YAMLGenerator.Feature.SPLIT_LINES)
                 val mapper = ObjectMapper(yamlFactory)
-                val handler = LoggingDeserializationProblemHandler()
-                mapper.addHandler(handler)
-                YamlHelper(mapper).toObject(externalConfigYaml, ExternalChangelogConfig::class.java)
+                val collectingHandler = CollectingDeserializationProblemHandler()
+                // Jackson prepends each handler to an internal linked list, so the last handler
+                // added is the first one called. CollectingDeserializationProblemHandler must be
+                // called first (returns false to continue the chain) so that
+                // LoggingDeserializationProblemHandler is also called (returns true to handle it).
+                mapper.addHandler(LoggingDeserializationProblemHandler())
+                mapper.addHandler(collectingHandler)
+                try {
+                    val config = YamlHelper(mapper).toObject(externalConfigYaml, ExternalChangelogConfig::class.java)
+                    collectingHandler.problems.forEach { problem -> println("⚠️  $problem") }
+                    config
+                } catch (e: RuntimeYamlException) {
+                    val cause = e.cause
+                    if (cause is InvalidFormatException) {
+                        println("⚠️  ${invalidFormatMessage(cause)}")
+                    }
+                    throw e
+                }
             }
         }
+    }
+
+    @VisibleForTesting
+    internal fun invalidFormatMessage(cause: InvalidFormatException): String {
+        val location = if (cause.location != null) " (line ${cause.location.lineNr}, column ${cause.location.columnNr})" else ""
+        return "Invalid value in configuration file$location: ${cause.originalMessage}"
     }
 
     fun buildCategoryConfig(
@@ -108,5 +135,21 @@ internal object ConfigHelpers {
             finalCategoryOrder,
             mergedCategoryToEmojiMappings
         )
+    }
+}
+
+private class CollectingDeserializationProblemHandler : DeserializationProblemHandler() {
+
+    val problems = mutableListOf<String>()
+
+    override fun handleUnknownProperty(
+        ctxt: DeserializationContext,
+        p: JsonParser,
+        deserializer: JsonDeserializer<*>,
+        beanOrClass: Any,
+        propertyName: String
+    ): Boolean {
+        problems.add("Unknown property '$propertyName' in configuration file")
+        return false  // let LoggingDeserializationProblemHandler handle it next
     }
 }

--- a/src/test/kotlin/org/kiwiproject/changelog/config/ConfigHelpersTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/config/ConfigHelpersTest.kt
@@ -1,16 +1,22 @@
 package org.kiwiproject.changelog.config
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.kiwiproject.changelog.config.external.ExternalCategory
 import org.kiwiproject.changelog.config.external.ExternalChangelogConfig
+import org.kiwiproject.changelog.junit.StdIoExtension
 import org.kiwiproject.test.util.Fixtures.fixture
 import org.kiwiproject.test.util.Fixtures.fixturePath
+import org.kiwiproject.yaml.RuntimeYamlException
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
@@ -137,6 +143,77 @@ class ConfigHelpersTest {
                 "Assorted",
                 "Dependency Updates"
             )
+        }
+    }
+
+    @Nested
+    inner class ExternalConfigFromYaml {
+
+        @RegisterExtension
+        private val stdIo = StdIoExtension()
+
+        @Test
+        fun shouldPrintWarning_WhenConfigContainsUnknownProperty() {
+            val yaml = """
+                ---
+                unknownProperty: true
+            """.trimIndent()
+
+            ConfigHelpers.externalConfig(yaml)
+
+            assertThat(stdIo.capturedLines()).anyMatch { it.contains("Unknown property 'unknownProperty' in configuration file") }
+        }
+
+        @Test
+        fun shouldPrintWarningAndRethrow_WhenConfigContainsInvalidTypeForProperty() {
+            val yaml = """
+                ---
+                hyperlinks: not-a-boolean
+            """.trimIndent()
+
+            assertThatThrownBy { ConfigHelpers.externalConfig(yaml) }
+                .isInstanceOf(RuntimeYamlException::class.java)
+                .hasCauseInstanceOf(InvalidFormatException::class.java)
+
+            assertThat(stdIo.capturedLines()).anyMatch { it.contains("Invalid value in configuration file") }
+        }
+
+        @Test
+        fun shouldRethrowWithoutPrinting_WhenCauseIsNotInvalidFormatException() {
+            // "@" is a reserved character in YAML and causes a JsonParseException, not an InvalidFormatException
+            val yaml = "---\n@invalid"
+
+            val thrown = catchThrowable { ConfigHelpers.externalConfig(yaml) }
+            assertThat(thrown).isInstanceOf(RuntimeYamlException::class.java)
+            assertThat(thrown.cause).isNotInstanceOf(InvalidFormatException::class.java)
+            assertThat(stdIo.capturedLines()).noneMatch { it.contains("Invalid value in configuration file") }
+        }
+    }
+
+    @Nested
+    inner class InvalidFormatMessage {
+
+        @Test
+        fun shouldIncludeLineAndColumn_WhenLocationIsPresent() {
+            val yaml = "---\nhyperlinks: not-a-boolean"
+            val cause = runCatching { ConfigHelpers.externalConfig(yaml) }
+                .exceptionOrNull()
+                ?.cause as? InvalidFormatException
+                ?: error("Expected RuntimeYamlException with InvalidFormatException cause")
+
+            val message = ConfigHelpers.invalidFormatMessage(cause)
+
+            assertThat(message).contains("Invalid value in configuration file (line")
+            assertThat(message).contains("column")
+        }
+
+        @Test
+        fun shouldNotIncludeLineAndColumn_WhenLocationIsNull() {
+            val exception = InvalidFormatException.from(null, "test message", "bad-value", Boolean::class.java)
+
+            val message = ConfigHelpers.invalidFormatMessage(exception)
+
+            assertThat(message).isEqualTo("Invalid value in configuration file: test message")
         }
     }
 


### PR DESCRIPTION
## Summary

- Print a warning to stdout when the external config file contains unknown properties
- Print a warning and rethrow when the config file contains a type mismatch (e.g. `hyperlinks: not-a-boolean`)
- Extract `invalidFormatMessage()` as a `@VisibleForTesting` helper that includes line/column info when available
- Add `CollectingDeserializationProblemHandler` to gather unknown-property warnings while keeping `LoggingDeserializationProblemHandler` in the chain
- Use `StdIoExtension` (existing JUnit 5 helper) in tests for capturing stdout

Closes #350 (fifth improvement — the TODO in ConfigHelpers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)