### PR TITLE
chore(ci): add permissions block to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,11 @@ on:
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
## Summary

- Adds a top-level permissions block to build.yml limiting GITHUB_TOKEN
  to contents:read and pull-requests:write
- contents:read is required for actions/checkout
- pull-requests:write is required for SonarCloud PR decoration
- codeql.yml already has a job-level permissions block; no changes needed
- dependabot.yml is a configuration file and does not use GITHUB_TOKEN;
  no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)