### PR TITLE
feat(install): support custom Logback configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,27 @@ use the `--ignore-config-files` (or `-g`) command line flag.
 You can also override the above and specify a custom configuration file using the
 `--config-file` (or `-n`) command line option, e.g. `--config-file /path/to/custom/changelog.yml`.
 
+## Logging configuration
+
+By default, logging is written to stdout. Application-level messages are logged at INFO and above;
+all other messages are logged at WARN and above.
+
+To customize logging (for example, to log to a file instead of stdout), place a `logback.xml` file
+in `~/.kiwi-changelog/`. The launcher script will detect it automatically and use it in place of
+the default configuration.
+
+A sample configuration file is included in the installation directory as `logback-sample.xml`. It
+configures a rolling file appender that writes to `~/.kiwi-changelog/logs/kiwi-changelog.log`,
+keeping up to 5 files of 10MB each (50MB total). To use it:
+
+```shell
+mkdir -p ~/.kiwi-changelog
+cp ~/kiwiproject-changelog-script/logback-sample.xml ~/.kiwi-changelog/logback.xml
+```
+
+Then customize `~/.kiwi-changelog/logback.xml` as needed. See the
+[Logback configuration documentation](https://logback.qos.ch/manual/configuration.html) for details.
+
 ## Example usage with a configuration file
 
 If you export `KIWI_CHANGELOG_TOKEN` to your environment, and you use a configuration file, then

--- a/etc/install/generate-kiwi-changelog.sh
+++ b/etc/install/generate-kiwi-changelog.sh
@@ -7,5 +7,16 @@
 # Get the directory of the script
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
+# Use custom Logback config if present in ~/.kiwi-changelog/
+logback_opt=""
+if [ -f "$HOME/.kiwi-changelog/logback.xml" ]; then
+    logback_opt="-Dlogback.configurationFile=$HOME/.kiwi-changelog/logback.xml"
+    echo "ℹ️  Using custom Logback config: $HOME/.kiwi-changelog/logback.xml"
+fi
+
 # Execute the JAR, passing through all arguments
-java -jar "${script_dir}/kiwi-changelog-generator.jar" "$@"
+if [ -n "$logback_opt" ]; then
+    java "$logback_opt" -jar "${script_dir}/kiwi-changelog-generator.jar" "$@"
+else
+    java -jar "${script_dir}/kiwi-changelog-generator.jar" "$@"
+fi

--- a/etc/install/install.sh
+++ b/etc/install/install.sh
@@ -139,6 +139,7 @@ echo "📄  Copy files to installation directory"
 changelog_script_path="${install_dir}/${changelog_script_name}"
 cp "etc/install/README.txt" "$install_dir"
 cp "etc/install/generate-kiwi-changelog.sh" "$changelog_script_path"
+cp "etc/install/logback-sample.xml" "$install_dir"
 cp "$jar_file" "${install_dir}/kiwi-changelog-generator.jar"
 
 # Ensure the changelog script is executable
@@ -177,4 +178,12 @@ echo "${changelog_script_path} -V"
 echo
 echo "Or if you added the changelog script directory to PATH:"
 echo "${changelog_script_name} -h"
+echo
+echo "✅ To enable custom logging (e.g. log to a file), copy the sample Logback"
+echo "configuration to ~/.kiwi-changelog/logback.xml and customize it:"
+echo
+echo "mkdir -p ~/.kiwi-changelog"
+echo "cp ${install_dir}/logback-sample.xml ~/.kiwi-changelog/logback.xml"
+echo
+echo "See the README for more details on logging configuration."
 echo

--- a/etc/install/logback-sample.xml
+++ b/etc/install/logback-sample.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<!--
+  Sample Logback configuration for kiwiproject-changelog.
+
+  To use this file, copy it to ~/.kiwi-changelog/logback.xml and
+  customize as needed. It will be picked up automatically by the
+  generate-kiwi-changelog.sh launcher script.
+
+  See https://logback.qos.ch/manual/configuration.html for full
+  Logback configuration documentation.
+-->
+
+<configuration>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${user.home}/.kiwi-changelog/logs/kiwi-changelog.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${user.home}/.kiwi-changelog/logs/kiwi-changelog.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>5</maxHistory>
+            <totalSizeCap>50MB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{5} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.kiwiproject.changelog" level="INFO"/>
+
+    <root level="WARN">
+        <appender-ref ref="FILE"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## Summary

- Launcher script checks for ~/.kiwi-changelog/logback.xml and passes
  it via -Dlogback.configurationFile if present; prints a message to
  stdout when a custom config is detected
- Adds logback-sample.xml with a rolling file appender writing to
  ~/.kiwi-changelog/logs/ (10MB per file, 5 files max, 50MB total)
- Install script copies logback-sample.xml to the install directory
  and adds post-install instructions for enabling custom logging
- README has a new Logging configuration section

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)