### PR TITLE
feat(logging): add error and warning logging for failure cases

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/App.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/App.kt
@@ -14,6 +14,7 @@ import org.kiwiproject.changelog.github.GitHubMilestoneManager
 import org.kiwiproject.changelog.github.GitHubPagingHelper
 import org.kiwiproject.changelog.github.GitHubReleaseManager
 import org.kiwiproject.changelog.github.GitHubSearchManager
+import io.github.oshai.kotlinlogging.KotlinLogging
 import picocli.CommandLine
 import picocli.CommandLine.Command
 import picocli.CommandLine.ITypeConverter
@@ -69,6 +70,8 @@ import kotlin.system.exitProcess
         ""
     ]
 )
+private val LOG = KotlinLogging.logger {}
+
 class App : Runnable {
 
     class VersionProvider : IVersionProvider {
@@ -279,6 +282,15 @@ class App : Runnable {
             return
         }
 
+        try {
+            runChangelog()
+        } catch (e: Exception) {
+            LOG.error(e) { "Changelog generation failed: ${e.message}" }
+            throw e
+        }
+    }
+
+    private fun runChangelog() {
         println("⚙️  Generating change log for version $revision")
 
         val githubToken = token ?: System.getenv("KIWI_CHANGELOG_TOKEN")

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GitHubApi.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GitHubApi.kt
@@ -83,6 +83,12 @@ class GitHubApi(
                 " Resource: ${response.rateLimitResource}"
         LOG.at(humanTimeUntilReset.logLevel) { this.message = rateLimitLogMessage }
 
+        if (!response.belowRateLimit()) {
+            LOG.error {
+                "Rate limit exceeded for resource: ${response.rateLimitResource}." +
+                        " No more requests can be made to that resource until $rateLimitReset (${humanTimeUntilReset.message})"
+            }
+        }
         check(response.belowRateLimit()) {
             IllegalStateException(
                 "Rate limit exceeded for resource: ${response.rateLimitResource}." +

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GitHubSearchManager.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GitHubSearchManager.kt
@@ -136,7 +136,9 @@ class GitHubSearchManager(
         return if (commitContainer["author"] != null) {
             gitHubUserFrom(authorName, commitContainer)
         } else {
-            println("⚠️  WARN: Commit has null author: API: ${commitContainer["url"]} , HTML: ${commitContainer["html_url"]}")
+            val message = "Commit has null author: API: ${commitContainer["url"]}, HTML: ${commitContainer["html_url"]}"
+            LOG.warn { message }
+            println("⚠️  WARN: $message")
             GitHubUser(authorName, null, null)
         }
     }


### PR DESCRIPTION
## Summary

- Wraps App.run() in a try-catch that logs any exception at ERROR
  before rethrowing, so all failures (bad revision, missing tag, API
  errors, etc.) are captured in the log regardless of where they occur
- Adds LOG.error before the rate limit exceeded check in GitHubApi
  so it is recorded in the log as well as in the exception message
- Promotes the null commit author warning in GitHubSearchManager to
  also log at WARN in addition to printing to stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)