### PR TITLE
feat(changelog): add milestone link to generated changelog

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/App.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/App.kt
@@ -245,6 +245,12 @@ class App : Runnable {
     )
     var hyperlinks: Boolean? = null
 
+    @Option(
+        names = ["--add-milestone-link"],
+        description = ["When set, appends a link to the closed milestone issues at the end of the generated changelog."]
+    )
+    var addMilestoneLink: Boolean? = null
+
     // Summary options
 
     @Option(
@@ -327,17 +333,23 @@ class App : Runnable {
         }
         val out = outputFile?.let { File(it) }
 
+        val githubApi = GitHubApi(githubToken)
+        val mapper = jacksonObjectMapper()
+        val milestoneManager = GitHubMilestoneManager(repoConfig, githubApi, mapper)
+
+        val shouldAddMilestoneLink = addMilestoneLink ?: externalConfig.addMilestoneLink
+        val milestoneLink = resolveMilestoneLink(shouldAddMilestoneLink, repoConfig, milestoneManager)
+
         val useTagDate = useTagDateForRelease ?: externalConfig.useTagDateForRelease
         val changeLogConfig = ChangelogConfig(
             useTagDateForRelease = useTagDate,
             outputType = outputType,
             outputFile = out,
             categoryConfig = categoryConfig,
-            summary = resolveSummary(summary, summaryFile, spec)
+            summary = resolveSummary(summary, summaryFile, spec),
+            milestoneLink = milestoneLink
         )
 
-        val githubApi = GitHubApi(githubToken)
-        val mapper = jacksonObjectMapper()
         val releaseManager = GitHubReleaseManager(repoConfig, githubApi, mapper)
         val gitHubPagingHelper = GitHubPagingHelper()
         val searchManager = GitHubSearchManager(repoConfig, githubApi, gitHubPagingHelper, mapper)
@@ -353,7 +365,6 @@ class App : Runnable {
         println("✔ Number of commits: ${generateResult.commitCount}")
 
         // Optional: close the milestone
-        val milestoneManager = GitHubMilestoneManager(repoConfig, githubApi, mapper)
         val shouldCloseMilestone = closeMilestone ?: externalConfig.closeMilestone
         val shouldUseHyperlinks = hyperlinks ?: externalConfig.hyperlinks
         if (shouldCloseMilestone) {
@@ -411,6 +422,7 @@ class App : Runnable {
         println("✔ stripVPrefixFromNextMilestone = $stripVPrefixFromNextMilestone")
         println("✔ addVPrefixToRevisions = $addVPrefixToRevisions")
         println("✔ hyperlinks = $hyperlinks")
+        println("✔ addMilestoneLink = $addMilestoneLink")
 
         // Debug options
         println("✔ debugArgs = $debugArgs")
@@ -512,6 +524,27 @@ class App : Runnable {
             }
 
             return milestoneManager.createMilestone(title)
+        }
+
+        @VisibleForTesting
+        fun resolveMilestoneLink(
+            shouldAddMilestoneLink: Boolean,
+            repoConfig: RepoConfig,
+            milestoneManager: GitHubMilestoneManager
+        ): String? {
+            if (!shouldAddMilestoneLink) return null
+
+            val milestoneTitle = repoConfig.milestone()
+            LOG.debug { "Looking up milestone '$milestoneTitle' to build milestone link" }
+            val milestone = milestoneManager.getOpenMilestoneByTitleOrNull(milestoneTitle)
+
+            return if (milestone != null) {
+                "${milestone.htmlUrl}?closed=1"
+            } else {
+                LOG.warn { "Milestone '$milestoneTitle' not found; milestone link will not be added to changelog" }
+                println("⚠️  Milestone '$milestoneTitle' not found; milestone link will not be added to changelog")
+                null
+            }
         }
     }
 }

--- a/src/main/kotlin/org/kiwiproject/changelog/ChangeLogFormatter.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/ChangeLogFormatter.kt
@@ -24,7 +24,7 @@ fun formatChangeLog(
         ## Summary
         - @date@ - [@commitCount@ commit(s)](@repoUrl@/compare/@previousRev@...@newRev@) by @authors@
 
-        @summary@@changes@
+        @summary@@changes@@milestoneLink@
     """.trimIndent()
 
     val authors = commitAuthorsResult.authors.joinToString(", ") { author -> author.asMarkdown() }
@@ -47,7 +47,11 @@ fun formatChangeLog(
             repoConfig.milestone(),
             changelogConfig.categoryConfig.categoryOrder,
             changelogConfig.categoryConfig.categoryToEmoji
-        )
+        ),
+        "milestoneLink" to when (val link = changelogConfig.milestoneLink) {
+            null -> ""
+            else -> "See associated milestone: $link\n"
+        }
     )
 
     return replaceTokens(template, logData)

--- a/src/main/kotlin/org/kiwiproject/changelog/config/ChangelogConfig.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/config/ChangelogConfig.kt
@@ -18,5 +18,6 @@ data class ChangelogConfig(
     val outputType: OutputType = OutputType.CONSOLE,
     val outputFile: File? = null,
     val categoryConfig: CategoryConfig = CategoryConfig.empty(),
-    val summary: String? = null
+    val summary: String? = null,
+    val milestoneLink: String? = null
 )

--- a/src/main/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfig.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfig.kt
@@ -11,6 +11,7 @@ data class ExternalChangelogConfig(
     val addVPrefixToRevisions: Boolean = false,
     val closeMilestone: Boolean = false,
     val hyperlinks: Boolean = false,
+    val addMilestoneLink: Boolean = false,
     val useTagDateForRelease: Boolean = false
 ) {
 

--- a/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
@@ -72,6 +72,7 @@ class AppTest {
             { assertThat(app.createNextMilestone).isNull() },
             { assertThat(app.addVPrefixToRevisions).isNull() },
             { assertThat(app.hyperlinks).isNull() },
+            { assertThat(app.addMilestoneLink).isNull() },
         )
     }
 
@@ -193,6 +194,7 @@ class AppTest {
                 "--strip-v-prefix-from-next-milestone",
                 "--add-v-prefix-to-revisions",
                 "--hyperlinks",
+                "--add-milestone-link",
                 "--summary",
                 "This is a cool summary of the release!"
             )
@@ -252,6 +254,7 @@ class AppTest {
         assertThat(app.stripVPrefixFromNextMilestone).isTrue()
         assertThat(app.addVPrefixToRevisions).isTrue()
         assertThat(app.hyperlinks).isTrue()
+        assertThat(app.addMilestoneLink).isTrue()
     }
 
     @ParameterizedTest
@@ -489,6 +492,60 @@ class AppTest {
         )
 
         assertThat(app.hyperlinks).isFalse()
+    }
+
+    @Nested
+    inner class ResolveMilestoneLink {
+
+        private val url = "https://fake-github.com"
+        private val apiUrl = "https://api.fake-github.com"
+        private val token = "abc-123"
+        private val repository = "fakeorg/fakerepo"
+        private val urlPrefix = "https://fake-github.com/fakeorg/fakerepo/milestones/"
+
+        private lateinit var milestoneManager: GitHubMilestoneManager
+
+        @BeforeEach
+        fun setUp() {
+            milestoneManager = mock(GitHubMilestoneManager::class.java)
+        }
+
+        @Test
+        fun shouldReturnNull_WhenAddMilestoneLinkIsFalse() {
+            val repoConfig = RepoConfig(url, apiUrl, token, repository, "v1.4.1", "v1.5.0", milestone = null)
+            val result = App.resolveMilestoneLink(false, repoConfig, milestoneManager)
+
+            assertThat(result).isNull()
+            verifyNoMoreInteractions(milestoneManager)
+        }
+
+        @Test
+        fun shouldReturnClosedMilestoneUrl_WhenMilestoneFound() {
+            val number = 25
+            val title = "1.5.0"
+            val htmlUrl = urlPrefix + number
+            val milestone = GitHubMilestone(number, title, htmlUrl)
+            `when`(milestoneManager.getOpenMilestoneByTitleOrNull(anyString())).thenReturn(milestone)
+
+            val repoConfig = RepoConfig(url, apiUrl, token, repository, "v1.4.1", "v${title}", milestone = null)
+            val result = App.resolveMilestoneLink(true, repoConfig, milestoneManager)
+
+            assertThat(result).isEqualTo("$htmlUrl?closed=1")
+            verify(milestoneManager).getOpenMilestoneByTitleOrNull(title)
+            verifyNoMoreInteractions(milestoneManager)
+        }
+
+        @Test
+        fun shouldReturnNull_WhenMilestoneNotFound() {
+            `when`(milestoneManager.getOpenMilestoneByTitleOrNull(anyString())).thenReturn(null)
+
+            val repoConfig = RepoConfig(url, apiUrl, token, repository, "v1.4.1", "v1.5.0", milestone = null)
+            val result = App.resolveMilestoneLink(true, repoConfig, milestoneManager)
+
+            assertThat(result).isNull()
+            verify(milestoneManager).getOpenMilestoneByTitleOrNull("1.5.0")
+            verifyNoMoreInteractions(milestoneManager)
+        }
     }
 
     @Nested

--- a/src/test/kotlin/org/kiwiproject/changelog/ChangeLogFormatterKtTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/ChangeLogFormatterKtTest.kt
@@ -190,10 +190,56 @@ class ChangeLogFormatterKtTest {
             return repoConfig
         }
 
-        private fun changelogConfig(categoryConfig: CategoryConfig, summary: String? = null) = ChangelogConfig(
+        @Test
+        fun shouldGenerateMarkdownFormattedChanges_WithMilestoneLink() {
+            val authors = gitHubUsers()
+            val authorsResult = CommitAuthorsResult(authors, 4)
+            val changes = gitHubChanges()
+            val repoConfig = repoConfig()
+            val categoryConfig = categoryConfig()
+            val milestoneLink = "https://fake-github.com/fakeorg/fakerepo/milestone/42?closed=1"
+            val changelogConfig = changelogConfig(categoryConfig, milestoneLink = milestoneLink)
+
+            val changelog = formatChangeLog(
+                authorsResult,
+                changes,
+                repoConfig,
+                changelogConfig,
+                repoConfig.repoUrl(),
+                changelogConfig.date
+            )
+
+            assertThat(changelog.trim()).isEqualTo(
+                """
+                ## Summary
+                - 2024-07-13T15:44:45Z - [4 commit(s)](https://fake-github.com/fakeorg/fakerepo/compare/v1.4.1...v1.4.2) by [Scott Leberknight](https://fake-github.com/sleberknight), [dependabot[bot]](https://fake-github.com/apps/dependabot)
+
+                ## Improvements 🚀
+                * Make the foo better [(#142)](https://fake-github.com/fakeorg/fakerepo/issues/142)
+
+                ## Bugs 🪲
+                * Fix the space modulator [(#154)](https://fake-github.com/fakeorg/fakerepo/issues/154)
+
+                ## Documentation 🗒️
+                * Add more documentation to the bar and baz [(#150)](https://fake-github.com/fakeorg/fakerepo/issues/150)
+
+                ## Dependency Updates ⚙️
+                * Bump quux-core from 1.6.0 to 1.7.2 [(#151)](https://fake-github.com/fakeorg/fakerepo/pull/151)
+
+                See associated milestone: $milestoneLink
+            """.trimIndent()
+            )
+        }
+
+        private fun changelogConfig(
+            categoryConfig: CategoryConfig,
+            summary: String? = null,
+            milestoneLink: String? = null
+        ) = ChangelogConfig(
             date = ZonedDateTime.of(2024, 7, 13, 15, 44, 45, 34567, ZoneOffset.UTC),
             categoryConfig = categoryConfig,
-            summary = summary
+            summary = summary,
+            milestoneLink = milestoneLink
         )
 
         private fun categoryConfig() = CategoryConfig(

--- a/src/test/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfigTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/config/external/ExternalChangelogConfigTest.kt
@@ -70,6 +70,7 @@ class ExternalChangelogConfigTest {
             { assertThat(config.addVPrefixToRevisions).isFalse() },
             { assertThat(config.closeMilestone).isFalse() },
             { assertThat(config.hyperlinks).isFalse() },
+            { assertThat(config.addMilestoneLink).isFalse() },
             { assertThat(config.useTagDateForRelease).isFalse() }
         )
     }
@@ -161,8 +162,17 @@ class ExternalChangelogConfigTest {
             { assertThat(config.addVPrefixToRevisions).isFalse() },
             { assertThat(config.closeMilestone).isFalse() },
             { assertThat(config.hyperlinks).isFalse() },
+            { assertThat(config.addMilestoneLink).isFalse() },
             { assertThat(config.useTagDateForRelease).isFalse() }
         )
+    }
+
+    @Test
+    fun shouldReadConfig_ThatHasAddMilestoneLink() {
+        val yaml = Fixtures.fixture("kiwi-changelog-configs/kiwi-changelog-add-milestone-link.yml")
+        val config = readConfig(yaml)
+
+        assertThat(config.addMilestoneLink).isTrue()
     }
 
     private fun readConfig(yaml: String) = yamlHelper.toObject(yaml, ExternalChangelogConfig::class.java)

--- a/src/test/resources/kiwi-changelog-configs/kiwi-changelog-add-milestone-link.yml
+++ b/src/test/resources/kiwi-changelog-configs/kiwi-changelog-add-milestone-link.yml
@@ -1,0 +1,1 @@
+addMilestoneLink: true


### PR DESCRIPTION
## Summary

- Adds --add-milestone-link CLI option and addMilestoneLink YAML config
  field (default: false)
- When enabled, appends a link to the closed milestone issues at the
  end of the generated changelog content, e.g.:
  See associated milestone: https://github.com/.../milestone/25?closed=1
- Milestone number is looked up via the API; if not found, a warning
  is logged and printed and the link is omitted rather than failing

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)