### PR TITLE
fix: handle already-closed or missing milestone gracefully in closeMilestone

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/App.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/App.kt
@@ -368,8 +368,15 @@ class App : Runnable {
         val shouldCloseMilestone = closeMilestone ?: externalConfig.closeMilestone
         val shouldUseHyperlinks = hyperlinks ?: externalConfig.hyperlinks
         if (shouldCloseMilestone) {
-            val closedMilestone = closeMilestone(repoConfig, milestone, milestoneManager)
-            println("✅ Closed milestone ${closedMilestone.title}. See it at ${formatUrl(closedMilestone.htmlUrl, shouldUseHyperlinks)}")
+            println("⚙️  Closing milestone ${repoConfig.milestone()}")
+            when (val result = closeMilestone(repoConfig, milestone, milestoneManager)) {
+                is CloseMilestoneResult.Closed ->
+                    println("✅ Closed milestone ${result.milestone.title}. See it at ${formatUrl(result.milestone.htmlUrl, shouldUseHyperlinks)}")
+                is CloseMilestoneResult.AlreadyClosed ->
+                    println("⚠️  Milestone ${result.milestone.title} is already closed. Skipping.")
+                is CloseMilestoneResult.NotFound ->
+                    println("⚠️  Milestone ${result.title} not found. Skipping.")
+            }
         }
 
         // Optional: create a new milestone
@@ -503,14 +510,21 @@ class App : Runnable {
             repoConfig: RepoConfig,
             maybeMilestoneTitle: String?,
             milestoneManager: GitHubMilestoneManager
-        ): GitHubMilestone {
+        ): CloseMilestoneResult {
             val milestoneTitle = maybeMilestoneTitle ?: repoConfig.milestone()
-            println("⚙️  Closing milestone $milestoneTitle")
 
-            val milestone = milestoneManager.getOpenMilestoneByTitle(milestoneTitle)
-            val closedMilestone = milestoneManager.closeMilestone(milestone.number)
+            val openMilestone = milestoneManager.getOpenMilestoneByTitleOrNull(milestoneTitle)
+            if (openMilestone != null) {
+                val closed = milestoneManager.closeMilestone(openMilestone.number)
+                return CloseMilestoneResult.Closed(closed)
+            }
 
-            return closedMilestone
+            val closedMilestone = milestoneManager.getClosedMilestoneByTitleOrNull(milestoneTitle)
+            if (closedMilestone != null) {
+                return CloseMilestoneResult.AlreadyClosed(closedMilestone)
+            }
+
+            return CloseMilestoneResult.NotFound(milestoneTitle)
         }
 
         @VisibleForTesting
@@ -547,4 +561,10 @@ class App : Runnable {
             }
         }
     }
+}
+
+sealed class CloseMilestoneResult {
+    data class Closed(val milestone: GitHubMilestone) : CloseMilestoneResult()
+    data class AlreadyClosed(val milestone: GitHubMilestone) : CloseMilestoneResult()
+    data class NotFound(val title: String) : CloseMilestoneResult()
 }

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GitHubMilestoneManager.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GitHubMilestoneManager.kt
@@ -19,6 +19,9 @@ class GitHubMilestoneManager(
     private val listOpenMilestonesUrl =
         "${repoConfig.apiUrl}/repos/${repoConfig.repository}/milestones?state=open&per_page=50"
 
+    private val listClosedMilestonesUrl =
+        "${repoConfig.apiUrl}/repos/${repoConfig.repository}/milestones?state=closed&per_page=50"
+
     fun getOpenMilestoneByTitle(title: String): GitHubMilestone {
         val maybeMilestone = getOpenMilestoneByTitleOrNull(title)
         check(maybeMilestone != null) {
@@ -28,8 +31,14 @@ class GitHubMilestoneManager(
         return maybeMilestone
     }
 
-    fun getOpenMilestoneByTitleOrNull(title: String): GitHubMilestone? {
-        val response = api.get(listOpenMilestonesUrl)
+    fun getOpenMilestoneByTitleOrNull(title: String): GitHubMilestone? =
+        getMilestoneByTitleOrNull(title, listOpenMilestonesUrl, "open")
+
+    fun getClosedMilestoneByTitleOrNull(title: String): GitHubMilestone? =
+        getMilestoneByTitleOrNull(title, listClosedMilestonesUrl, "closed")
+
+    private fun getMilestoneByTitleOrNull(title: String, listUrl: String, state: String): GitHubMilestone? {
+        val response = api.get(listUrl)
         check(response.statusCode == 200) {
             "List milestones request failed. Status: ${response.statusCode}. Text: ${response.content}"
         }
@@ -45,12 +54,12 @@ class GitHubMilestoneManager(
 
         return when (foundMilestone) {
             null -> {
-                LOG.debug { "No open milestone found with title '$title'" }
+                LOG.debug { "No $state milestone found with title '$title'" }
                 null
             }
             else -> {
                 val milestone = GitHubMilestone.from(foundMilestone)
-                LOG.debug { "Found open milestone: #${milestone.number} '${milestone.title}'" }
+                LOG.debug { "Found $state milestone: #${milestone.number} '${milestone.title}'" }
                 milestone
             }
         }

--- a/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/AppTest.kt
@@ -331,49 +331,96 @@ class AppTest {
         }
 
         @Test
-        fun shouldClose_BasedOnRevision() {
+        fun shouldReturnClosed_BasedOnRevision() {
             val number = 1
             val title = "1.4.2"
             val htmlUrl = urlPrefix + number
             val milestone = GitHubMilestone(number, title, htmlUrl)
-            `when`(milestoneManager.getOpenMilestoneByTitle(anyString())).thenReturn(milestone)
+            `when`(milestoneManager.getOpenMilestoneByTitleOrNull(anyString())).thenReturn(milestone)
             `when`(milestoneManager.closeMilestone(anyInt())).thenReturn(milestone)
 
             val repoConfig = RepoConfig(url, apiUrl, token, repository, "v1.4.1", "v${title}", milestone = null)
-            val closedMilestone = App.closeMilestone(
+            val result = App.closeMilestone(
                 repoConfig = repoConfig,
                 maybeMilestoneTitle = null,
                 milestoneManager = milestoneManager
             )
 
-            assertThat(closedMilestone).isSameAs(milestone)
+            assertThat(result).isInstanceOf(CloseMilestoneResult.Closed::class.java)
+            assertThat((result as CloseMilestoneResult.Closed).milestone).isSameAs(milestone)
 
             verifyMilestoneManagerCalls(title, number)
         }
 
         @Test
-        fun shouldClose_UsingExplicitMilestone() {
+        fun shouldReturnClosed_UsingExplicitMilestone() {
             val number = 4
             val title = "1.5.0"
             val htmlUrl = urlPrefix + number
             val milestone = GitHubMilestone(number, title, htmlUrl)
-            `when`(milestoneManager.getOpenMilestoneByTitle(anyString())).thenReturn(milestone)
+            `when`(milestoneManager.getOpenMilestoneByTitleOrNull(anyString())).thenReturn(milestone)
             `when`(milestoneManager.closeMilestone(anyInt())).thenReturn(milestone)
 
             val repoConfig = RepoConfig(url, apiUrl, token, repository, "v1.4.1", "v${title}", milestone = null)
-            val closedMilestone = App.closeMilestone(
+            val result = App.closeMilestone(
                 repoConfig = repoConfig,
                 maybeMilestoneTitle = "1.5.0",
                 milestoneManager = milestoneManager
             )
 
-            assertThat(closedMilestone).isSameAs(milestone)
+            assertThat(result).isInstanceOf(CloseMilestoneResult.Closed::class.java)
+            assertThat((result as CloseMilestoneResult.Closed).milestone).isSameAs(milestone)
 
             verifyMilestoneManagerCalls(title, number)
         }
 
+        @Test
+        fun shouldReturnAlreadyClosed_WhenMilestoneIsAlreadyClosed() {
+            val number = 2
+            val title = "1.4.0"
+            val htmlUrl = urlPrefix + number
+            val milestone = GitHubMilestone(number, title, htmlUrl)
+            `when`(milestoneManager.getOpenMilestoneByTitleOrNull(anyString())).thenReturn(null)
+            `when`(milestoneManager.getClosedMilestoneByTitleOrNull(anyString())).thenReturn(milestone)
+
+            val repoConfig = RepoConfig(url, apiUrl, token, repository, "v1.3.9", "v${title}", milestone = null)
+            val result = App.closeMilestone(
+                repoConfig = repoConfig,
+                maybeMilestoneTitle = null,
+                milestoneManager = milestoneManager
+            )
+
+            assertThat(result).isInstanceOf(CloseMilestoneResult.AlreadyClosed::class.java)
+            assertThat((result as CloseMilestoneResult.AlreadyClosed).milestone).isSameAs(milestone)
+
+            verify(milestoneManager).getOpenMilestoneByTitleOrNull(title)
+            verify(milestoneManager).getClosedMilestoneByTitleOrNull(title)
+            verifyNoMoreInteractions(milestoneManager)
+        }
+
+        @Test
+        fun shouldReturnNotFound_WhenMilestoneDoesNotExist() {
+            val title = "1.4.0"
+            `when`(milestoneManager.getOpenMilestoneByTitleOrNull(anyString())).thenReturn(null)
+            `when`(milestoneManager.getClosedMilestoneByTitleOrNull(anyString())).thenReturn(null)
+
+            val repoConfig = RepoConfig(url, apiUrl, token, repository, "v1.3.9", "v${title}", milestone = null)
+            val result = App.closeMilestone(
+                repoConfig = repoConfig,
+                maybeMilestoneTitle = null,
+                milestoneManager = milestoneManager
+            )
+
+            assertThat(result).isInstanceOf(CloseMilestoneResult.NotFound::class.java)
+            assertThat((result as CloseMilestoneResult.NotFound).title).isEqualTo(title)
+
+            verify(milestoneManager).getOpenMilestoneByTitleOrNull(title)
+            verify(milestoneManager).getClosedMilestoneByTitleOrNull(title)
+            verifyNoMoreInteractions(milestoneManager)
+        }
+
         private fun verifyMilestoneManagerCalls(title: String, number: Int) {
-            verify(milestoneManager).getOpenMilestoneByTitle(title)
+            verify(milestoneManager).getOpenMilestoneByTitleOrNull(title)
             verify(milestoneManager).closeMilestone(number)
             verifyNoMoreInteractions(milestoneManager)
         }

--- a/src/test/kotlin/org/kiwiproject/changelog/github/GitHubMilestoneManagerTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/github/GitHubMilestoneManagerTest.kt
@@ -190,8 +190,93 @@ class GitHubMilestoneManagerTest {
         }
     }
 
+    @Nested
+    inner class GetClosedMilestoneByTitleOrNull {
+
+        @Test
+        fun shouldGetMilestone() {
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody(getClosedMilestonesResponseJson())
+                    .addJsonContentTypeHeader()
+                    .addGitHubRateLimitHeaders()
+            )
+
+            val milestone = milestoneManager.getClosedMilestoneByTitleOrNull("0.9.0-alpha")!!
+
+            assertMilestone(milestone)
+            assertListClosedMilestonesRequest()
+        }
+
+        @Test
+        fun shouldReturnNull_WhenDoesNotExist() {
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody(getClosedMilestonesResponseJson())
+                    .addJsonContentTypeHeader()
+                    .addGitHubRateLimitHeaders()
+            )
+
+            val milestone = milestoneManager.getClosedMilestoneByTitleOrNull("0.10.0")
+            assertThat(milestone).isNull()
+
+            assertListClosedMilestonesRequest()
+        }
+
+        @Test
+        fun shouldThrowIllegalState_WhenListMilestoneRequestFails() {
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(500)
+                    .setBody("List milestones failed")
+                    .addGitHubRateLimitHeaders()
+            )
+
+            assertThatIllegalStateException()
+                .isThrownBy { milestoneManager.getClosedMilestoneByTitleOrNull("0.9.0-alpha") }
+                .withMessage("List milestones request failed. Status: 500. Text: List milestones failed")
+
+            assertListClosedMilestonesRequest()
+        }
+
+        @Test
+        fun shouldThrowIllegalState_WhenGetLinkHeader() {
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody("[]")
+                    .addHeader("Link", "")
+                    .addJsonContentTypeHeader()
+                    .addGitHubRateLimitHeaders()
+            )
+
+            assertThatIllegalStateException()
+                .isThrownBy { milestoneManager.getClosedMilestoneByTitleOrNull("0.9.0-alpha") }
+                .withMessage("We received a Link header when we were not expecting it!")
+
+            assertListClosedMilestonesRequest()
+        }
+
+        private fun assertListClosedMilestonesRequest() {
+            val listMilestonesRequest = server.takeRequestWith1SecTimeout()
+
+            assertAll(
+                { assertThat(listMilestonesRequest.method).isEqualTo("GET") },
+                {
+                    assertThat(listMilestonesRequest.path)
+                        .isEqualTo("/repos/sleberknight/kotlin-scratch-pad/milestones?state=closed&per_page=50")
+                }
+            )
+        }
+    }
+
     private fun getOpenMilestonesResponseJson() =
         Fixtures.fixture("github-list-open-milestones-response.json")
+
+    private fun getClosedMilestonesResponseJson() =
+        Fixtures.fixture("github-list-closed-milestones-response.json")
 
     private fun assertListMilestonesRequest() {
         val listMilestonesRequest = server.takeRequestWith1SecTimeout()

--- a/src/test/resources/github-list-closed-milestones-response.json
+++ b/src/test/resources/github-list-closed-milestones-response.json
@@ -1,0 +1,39 @@
+[
+  {
+    "url": "https://api.fake-github.com/repos/sleberknight/kotlin-scratch-pad/milestones/1",
+    "html_url": "https://fake-github.com/sleberknight/kotlin-scratch-pad/milestone/1",
+    "labels_url": "https://api.fake-github.com/repos/sleberknight/kotlin-scratch-pad/milestones/1/labels",
+    "id": 11129075,
+    "node_id": "MI_kwDOLab6U84AqdDz",
+    "number": 1,
+    "title": "0.9.0-alpha",
+    "description": "",
+    "creator": {
+      "login": "sleberknight",
+      "id": 174812,
+      "node_id": "MDQ6VXNlcjE3NDgxMg==",
+      "avatar_url": "https://avatars.githubusercontent.com/u/174812?v=4",
+      "gravatar_id": "",
+      "url": "https://api.fake-github.com/users/sleberknight",
+      "html_url": "https://fake-github.com/sleberknight",
+      "followers_url": "https://api.fake-github.com/users/sleberknight/followers",
+      "following_url": "https://api.fake-github.com/users/sleberknight/following{/other_user}",
+      "gists_url": "https://api.fake-github.com/users/sleberknight/gists{/gist_id}",
+      "starred_url": "https://api.fake-github.com/users/sleberknight/starred{/owner}",
+      "subscriptions_url": "https://api.fake-github.com/users/sleberknight/subscriptions",
+      "organizations_url": "https://api.fake-github.com/users/sleberknight/orgs",
+      "repos_url": "https://api.fake-github.com/users/sleberknight/repos",
+      "events_url": "https://api.fake-github.com/users/sleberknight/events{/privacy}",
+      "received_events_url": "https://api.fake-github.com/users/sleberknight/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "open_issues": 0,
+    "closed_issues": 5,
+    "state": "closed",
+    "created_at": "2024-06-02T20:15:00Z",
+    "updated_at": "2024-06-07T22:03:14Z",
+    "due_on": null,
+    "closed_at": "2024-06-07T22:03:14Z"
+  }
+]


### PR DESCRIPTION
Previously, closeMilestone called getOpenMilestoneByTitle which threw IllegalStateException if the milestone was not found in the open list. This caused a resume to fail after an interrupted run where the changelog was written but the milestone was not yet closed.

The new behavior:

- Milestone is open: close it, return Closed (happy path, no change)
- Milestone is already closed: warn and return AlreadyClosed
- Milestone does not exist: warn and return NotFound

CloseMilestoneResult is a sealed class so the compiler enforces exhaustive handling at the call site, which now owns all user-facing output. GitHubMilestoneManager gains getClosedMilestoneByTitleOrNull, backed by a shared private helper to avoid duplication between the open and closed lookup paths.

Closes #389