### PR TITLE
fix: report actual GitHub error when rate-limit headers are missing

### DIFF
--- a/src/main/kotlin/org/kiwiproject/changelog/extension/HttpHeadersExtensions.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/extension/HttpHeadersExtensions.kt
@@ -3,19 +3,32 @@ package org.kiwiproject.changelog.extension
 import java.net.http.HttpHeaders
 import java.util.OptionalLong
 
+/**
+ * Thrown when an expected HTTP header is missing, or its value cannot be
+ * parsed as the requested type.
+ */
+class HttpHeaderException(message: String, cause: Throwable? = null) : IllegalStateException(message, cause)
+
 fun HttpHeaders.firstValueOrNull(name: String): String? = firstValue(name).orElse(null)
 
+/**
+ * Throws [HttpHeaderException] if the header does not exist (case-insensitive).
+ */
 fun HttpHeaders.firstValueOrThrow(name: String): String =
-    firstValue(name).orElseThrow { newIllegalStateException(name) }
+    firstValue(name).orElseThrow { newHttpHeaderException(name) }
 
+/**
+ * Throws [HttpHeaderException] if the header does not exist (case-insensitive),
+ * or if it exists but its value does not parse as a Long.
+ */
 fun HttpHeaders.firstValueAsLongOrThrow(name: String): Long {
     val optionalLong: OptionalLong? = try {
         firstValueAsLong(name)
     } catch (e: Exception) {
-        throw IllegalStateException("$name header exists, but its value does not parse as a Long", e)
+        throw HttpHeaderException("$name header exists, but its value does not parse as a Long", e)
     }
-    return optionalLong!!.orElseThrow { newIllegalStateException(name) }
+    return optionalLong!!.orElseThrow { newHttpHeaderException(name) }
 }
 
-private fun newIllegalStateException(name: String): IllegalStateException =
-    IllegalStateException("$name header was expected, but does not exist (case-insensitive)")
+private fun newHttpHeaderException(name: String): HttpHeaderException =
+    HttpHeaderException("$name header was expected, but does not exist (case-insensitive)")

--- a/src/main/kotlin/org/kiwiproject/changelog/github/GitHubResponse.kt
+++ b/src/main/kotlin/org/kiwiproject/changelog/github/GitHubResponse.kt
@@ -1,5 +1,7 @@
 package org.kiwiproject.changelog.github
 
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.kiwiproject.changelog.extension.HttpHeaderException
 import org.kiwiproject.changelog.extension.firstValueAsLongOrThrow
 import org.kiwiproject.changelog.extension.firstValueOrNull
 import org.kiwiproject.changelog.extension.firstValueOrThrow
@@ -8,6 +10,14 @@ import java.net.URI
 import java.net.http.HttpResponse
 import java.time.Duration
 import java.time.ZonedDateTime
+
+private val LOG = KotlinLogging.logger {}
+
+// GitHub error bodies are typically well under 300 characters, e.g.,
+// {"message": "Bad credentials","documentation_url": "..."}. Allow roughly
+// 4x that in the exception message, so most real error bodies, including
+// larger 422 validation payloads, come through without truncation.
+internal const val MAX_ERROR_BODY_LENGTH = 1200
 
 /**
  * Represents a generic GitHub response.
@@ -47,25 +57,70 @@ data class GitHubResponse(
 
         /**
          * Create a new GitHubResponse from the given HttpResponse.
+         *
+         * Throws [IllegalStateException] if the GitHub rate-limit headers cannot be parsed
+         * from the response, e.g., because the request failed (they are typically absent on
+         * an authentication failure) or an expected header was otherwise missing or malformed.
          */
         fun from(httpResponse: HttpResponse<String>): GitHubResponse {
-            val responseHeaders = httpResponse.headers()
-            val rateLimitLimit = responseHeaders.firstValueAsLongOrThrow("X-RateLimit-Limit")
-            val rateLimitRemaining = responseHeaders.firstValueAsLongOrThrow("X-RateLimit-Remaining")
-            val rateLimitResetEpochSeconds = responseHeaders.firstValueAsLongOrThrow("X-RateLimit-Reset")
-            val rateLimitResource = responseHeaders.firstValueOrThrow("X-RateLimit-Resource")
-            val link = responseHeaders.firstValueOrNull("Link")
+            val rateLimit = parseRateLimitHeaders(httpResponse)
+            val link = httpResponse.headers().firstValueOrNull("Link")
 
             return GitHubResponse(
                 httpResponse.statusCode(),
                 httpResponse.uri(),
                 httpResponse.body(),
                 link,
-                rateLimitLimit,
-                rateLimitRemaining,
-                rateLimitResetEpochSeconds,
-                rateLimitResource
+                rateLimit.limit,
+                rateLimit.remaining,
+                rateLimit.resetEpochSeconds,
+                rateLimit.resource
             )
         }
+
+        private fun parseRateLimitHeaders(httpResponse: HttpResponse<String>): RateLimitHeaders {
+            val responseHeaders = httpResponse.headers()
+            return try {
+                RateLimitHeaders(
+                    responseHeaders.firstValueAsLongOrThrow("X-RateLimit-Limit"),
+                    responseHeaders.firstValueAsLongOrThrow("X-RateLimit-Remaining"),
+                    responseHeaders.firstValueAsLongOrThrow("X-RateLimit-Reset"),
+                    responseHeaders.firstValueOrThrow("X-RateLimit-Resource")
+                )
+            } catch (e: HttpHeaderException) {
+                val statusCode = httpResponse.statusCode()
+                val uri = httpResponse.uri()
+                val body = httpResponse.body()
+
+                val message = if (statusCode in 200..299) {
+                    "GitHub API response from $uri was HTTP $statusCode but is missing an expected header:" +
+                            " ${e.message}. Body: ${truncateBody(body)}"
+                } else {
+                    val tokenHint = if (statusCode == 401 || statusCode == 403) {
+                        " Verify that the GitHub token is correct, complete, and not expired."
+                    } else {
+                        ""
+                    }
+                    "GitHub API request to $uri failed with HTTP $statusCode: ${truncateBody(body)}.$tokenHint"
+                }
+
+                LOG.error { "$message (untruncated body: $body)" }
+                throw IllegalStateException(message, e)
+            }
+        }
+
+        private fun truncateBody(body: String): String =
+            if (body.length <= MAX_ERROR_BODY_LENGTH) {
+                body
+            } else {
+                "${body.take(MAX_ERROR_BODY_LENGTH)}...(truncated, ${body.length} bytes total)"
+            }
     }
 }
+
+private data class RateLimitHeaders(
+    val limit: Long,
+    val remaining: Long,
+    val resetEpochSeconds: Long,
+    val resource: String
+)

--- a/src/test/kotlin/org/kiwiproject/changelog/extension/HttpHeadersExtensionsTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/extension/HttpHeadersExtensionsTest.kt
@@ -1,7 +1,7 @@
 package org.kiwiproject.changelog.extension
 
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatIllegalStateException
+import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -50,8 +50,8 @@ class HttpHeadersExtensionsTest {
         }
 
         @Test
-        fun shouldThrowIllegalState_WhenHeaderDoesNotExist() {
-            assertThatIllegalStateException()
+        fun shouldThrowHttpHeaderException_WhenHeaderDoesNotExist() {
+            assertThatExceptionOfType(HttpHeaderException::class.java)
                 .isThrownBy { httpHeaders.firstValueOrThrow("Link") }
                 .withMessage("Link header was expected, but does not exist (case-insensitive)")
         }
@@ -67,15 +67,15 @@ class HttpHeadersExtensionsTest {
         }
 
         @Test
-        fun shouldThrowIllegalState_WhenHeaderDoesNotExist() {
-            assertThatIllegalStateException()
+        fun shouldThrowHttpHeaderException_WhenHeaderDoesNotExist() {
+            assertThatExceptionOfType(HttpHeaderException::class.java)
                 .isThrownBy { httpHeaders.firstValueAsLongOrThrow("Some-Custom-Header") }
                 .withMessage("Some-Custom-Header header was expected, but does not exist (case-insensitive)")
         }
 
         @Test
-        fun shouldThrowIllegalState_WhenHeaderExists_ButValueIsNotConvertibleToLong() {
-            assertThatIllegalStateException()
+        fun shouldThrowHttpHeaderException_WhenHeaderExists_ButValueIsNotConvertibleToLong() {
+            assertThatExceptionOfType(HttpHeaderException::class.java)
                 .isThrownBy { httpHeaders.firstValueAsLongOrThrow("X-RateLimit-Resource") }
                 .withMessage("X-RateLimit-Resource header exists, but its value does not parse as a Long")
                 .havingCause()

--- a/src/test/kotlin/org/kiwiproject/changelog/github/GitHubApiTest.kt
+++ b/src/test/kotlin/org/kiwiproject/changelog/github/GitHubApiTest.kt
@@ -208,6 +208,77 @@ class GitHubApiTest {
     }
 
     @Nested
+    inner class RateLimitHeaderParsing {
+
+        @ParameterizedTest
+        @ValueSource(ints = [401, 403])
+        fun shouldThrowIllegalState_AndSuggestCheckingToken_WhenAuthFailureIsMissingRateLimitHeaders(statusCode: Int) {
+            val errorBody = """{"message":"Bad credentials","documentation_url":"https://docs.github.com/rest"}"""
+
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(statusCode)
+                    .setBody(errorBody)
+                    .addJsonContentTypeHeader()
+            )
+
+            val url = server.urlWithoutTrailingSlashAsString(ISSUES_PATH)
+            assertThatIllegalStateException()
+                .isThrownBy { githubApi.get(url) }
+                .withMessageContaining(url)
+                .withMessageContaining("HTTP $statusCode")
+                .withMessageContaining(errorBody)
+                .withMessageContaining("Verify that the GitHub token is correct, complete, and not expired.")
+
+            server.takeRequestWith1SecTimeout()
+            server.assertNoMoreRequests()
+        }
+
+        @Test
+        fun shouldNotSuggestCheckingToken_WhenNonAuthFailureIsMissingRateLimitHeaders() {
+            val errorBody = """{"message":"${"x".repeat(2_000)}"}"""
+
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(422)
+                    .setBody(errorBody)
+                    .addJsonContentTypeHeader()
+            )
+
+            val url = server.urlWithoutTrailingSlashAsString(ISSUES_PATH)
+            assertThatIllegalStateException()
+                .isThrownBy { githubApi.get(url) }
+                .withMessageContaining("HTTP 422")
+                .withMessageContaining("...(truncated, ${errorBody.length} bytes total)")
+                .withMessageNotContaining(errorBody)
+                .withMessageNotContaining("Verify that the GitHub token")
+
+            server.takeRequestWith1SecTimeout()
+            server.assertNoMoreRequests()
+        }
+
+        @Test
+        fun shouldThrowIllegalState_WhenSuccessfulResponseIsMissingRateLimitHeaders() {
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setBody("[]")
+                    .addJsonContentTypeHeader()
+            )
+
+            val url = server.urlWithoutTrailingSlashAsString(ISSUES_PATH)
+            assertThatIllegalStateException()
+                .isThrownBy { githubApi.get(url) }
+                .withMessageContaining(url)
+                .withMessageContaining("was HTTP 200 but is missing an expected header")
+                .withMessageContaining("X-RateLimit-Limit header was expected, but does not exist")
+
+            server.takeRequestWith1SecTimeout()
+            server.assertNoMoreRequests()
+        }
+    }
+
+    @Nested
     inner class HumanTimeUntilReset {
 
         @ParameterizedTest


### PR DESCRIPTION
GitHubResponse.from assumed every response carried valid X-RateLimit-* headers, so a failed request (e.g. an expired or truncated token producing a 401) failed on the missing header instead of the real cause, hiding the actual GitHub error behind a generic header-parsing exception.

Header parsing failures now raise a dedicated HttpHeaderException from the HttpHeaders extensions. GitHubResponse wraps just the rate-limit header parsing to report the HTTP status, request URI, and response body (truncated for very large bodies) instead of a bare "header was expected" message, with a hint to check the token on 401/403 responses.

Existing per-call-site status checks in GitHubReleaseManager are unaffected, since GitHub still returns rate-limit headers on most non-2xx responses; they are only absent on auth failures.

Closes #406